### PR TITLE
Fix tests failing due to missing package path

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Ensure 'src' directory is on sys.path for tests
+PROJECT_ROOT = Path(__file__).resolve().parent
+SRC_DIR = PROJECT_ROOT / 'src'
+if SRC_DIR.exists() and str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))


### PR DESCRIPTION
## Summary
- ensure test runs can import package without installation by adding `src` to `sys.path`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895602ace388328b379208c9efa8230