### PR TITLE
Allow passing Sigil instance to GUI

### DIFF
--- a/src/pysigil/hub.py
+++ b/src/pysigil/hub.py
@@ -151,7 +151,9 @@ def get_preferences(
 
         sigil = _lazy()
         # Pass the resolved Sigil instance so that the editor reflects the
-        # caller's package-specific defaults and metadata.
-        _launch(sigil=sigil)
+        # caller's package-specific defaults and metadata. Include any
+        # previously instantiated packages in the selection list.
+        pkgs = sorted({sigil.app_name, *_instances.keys(), "pysigil"})
+        _launch(sigil=sigil, packages=pkgs)
 
     return get_pref, set_pref, effective_scope_for, launch_gui

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -14,7 +14,7 @@ def test_get_preferences_launch_gui(tmp_path, monkeypatch):
 
     called: dict[str, object] = {}
 
-    def fake_launch(*, package=None, allow_default_write=True, sigil=None):
+    def fake_launch(*, sigil=None, **kwargs):
         called["sigil"] = sigil
 
     monkeypatch.setattr("pysigil.gui.launch_gui", fake_launch)


### PR DESCRIPTION
## Summary
- let `gui.launch_gui` accept an existing `Sigil` instance and ensure it becomes the active package
- include previously instantiated packages when launching the GUI via `hub.get_preferences`
- adjust tests for the updated GUI launcher interface

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/gui.py src/pysigil/hub.py tests/test_hub.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68966eae115c8328a057b7f676c17128