### PR TITLE
Load defaults when switching GUI package

### DIFF
--- a/src/pysigil/gui_state.py
+++ b/src/pysigil/gui_state.py
@@ -9,7 +9,8 @@ try:
 except ModuleNotFoundError:  # pragma: no cover
     from ._appdirs_stub import user_config_dir
 
-STATE_PATH = Path(user_config_dir("pysigil")) / "gui_state.json"
+# Store GUI state alongside preference files under the same base directory.
+STATE_PATH = Path(user_config_dir("sigil")) / "gui_state.json"
 
 
 def read_state(path: Path | None = None) -> dict:


### PR DESCRIPTION
## Summary
- Ensure switching packages in the preferences GUI loads the package through the hub so defaults and metadata are respected
- Store GUI state under Sigil's config root so state and preferences live in the same directory

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/gui_state.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689783905c288328b66e3061b1640624