### PR TITLE
Add GUI debug logging and restore preference controls

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -9,3 +9,10 @@ sigil-gui --app myapp
 
 This opens a window showing all preferences defined for *myapp* using the
 metadata loaded from `defaults.meta.csv` if present.
+
+## Debug logging
+
+Set the environment variable `SIGIL_GUI_DEBUG=1` before launching the GUI to
+emit verbose debug information to the console.  This can help diagnose problems
+with package loading or preference updates and can be disabled by unsetting the
+variable.


### PR DESCRIPTION
## Summary
- enable optional GUI debug logging via `SIGIL_GUI_DEBUG` env var
- restore Add/Edit/Delete preference buttons and auto-refresh tree
- document debug toggle in GUI docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689787b4ad80832883592b1a6a4384c2