### PR TITLE
feat: implement project resolution and provider schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,12 @@ sigil-gui = "pysigil.gui:launch_gui"
 [tool.ruff]
 line-length = 88
 target-version = "py311"
-select = ["F", "E", "W", "I", "B", "UP", "N"]
-ignore = ["E501", "N801", "N812", "N815"]
 fix = true
 unsafe-fixes = false
+
+[tool.ruff.lint]
+select = ["F", "E", "W", "I", "B", "UP", "N"]
+ignore = ["E501", "N801", "N812", "N815"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["pysigil"]

--- a/src/pysigil/api.py
+++ b/src/pysigil/api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 from .backend_ini import read_sections, write_sections
 from .core_defaults import CORE_DEFAULTS
@@ -23,7 +22,7 @@ def _find_distribution(provider_id: str):  # pragma: no cover - thin wrapper
     except Exception:  # pragma: no cover
         return None
     for dist in distributions():
-        name = getattr(dist, "metadata", {}).get("Name") or getattr(dist, "name")
+        name = getattr(dist, "metadata", {}).get("Name") or dist.name
         if name and pep503_name(name) == provider_id:
             return dist
     return None
@@ -45,9 +44,9 @@ def get_value(
     provider_id: str,
     dotted_key: str,
     *,
-    project_file: Optional[Path] = None,
-    app: Optional[str] = None,
-) -> Optional[str]:
+    project_file: Path | None = None,
+    app: str | None = None,
+) -> str | None:
     app_name = app or provider_id
     project_path = project_settings_file(project_file)
     user_path = _user_settings_path(app_name)
@@ -86,7 +85,7 @@ def set_project_value(
     dotted_key: str,
     value: str,
     *,
-    project_file: Optional[Path] = None,
+    project_file: Path | None = None,
 ) -> None:
     path = project_settings_file(project_file)
     data = read_sections(path)
@@ -100,7 +99,7 @@ def set_user_value(
     dotted_key: str,
     value: str,
     *,
-    app: Optional[str] = None,
+    app: str | None = None,
 ) -> None:
     app_name = app or provider_id
     path = _user_settings_path(app_name)

--- a/src/pysigil/api.py
+++ b/src/pysigil/api.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from .backend_ini import read_sections, write_sections
+from .core_defaults import CORE_DEFAULTS
+from .defaults import DefaultsFormatError, load_provider_defaults
+from .provider_id import pep503_name
+from .resolver import DEFAULT_FILENAME, project_settings_file
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _user_settings_path(app: str) -> Path:
+    return Path.home() / ".config" / app / DEFAULT_FILENAME
+
+
+def _find_distribution(provider_id: str):  # pragma: no cover - thin wrapper
+    try:
+        from importlib.metadata import distributions
+    except Exception:  # pragma: no cover
+        return None
+    for dist in distributions():
+        name = getattr(dist, "metadata", {}).get("Name") or getattr(dist, "name")
+        if name and pep503_name(name) == provider_id:
+            return dist
+    return None
+
+
+def _merge_dicts(chain):
+    result = {}
+    for d in chain:
+        for section, kv in d.items():
+            result.setdefault(section, {}).update(kv)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def get_value(
+    provider_id: str,
+    dotted_key: str,
+    *,
+    project_file: Optional[Path] = None,
+    app: Optional[str] = None,
+) -> Optional[str]:
+    app_name = app or provider_id
+    project_path = project_settings_file(project_file)
+    user_path = _user_settings_path(app_name)
+
+    project_sections = read_sections(project_path)
+    user_sections = read_sections(user_path)
+
+    defaults = {}
+    dist = _find_distribution(provider_id)
+    if dist is not None:
+        try:
+            defaults = load_provider_defaults(provider_id, dist)
+        except DefaultsFormatError:
+            defaults = {}
+
+    policy = CORE_DEFAULTS.get("pysigil", {}).get("policy", "project_over_user")
+    policy = defaults.get("pysigil", {}).get("policy", policy)
+    policy = project_sections.get("pysigil", {}).get("policy", policy)
+    policy = user_sections.get("pysigil", {}).get("policy", policy)
+
+    chain = [CORE_DEFAULTS]
+    if defaults:
+        chain.append(defaults)
+    if policy == "project_over_user":
+        chain.extend([user_sections, project_sections])
+    else:
+        chain.extend([project_sections, user_sections])
+    merged = _merge_dicts(chain)
+
+    section = f"provider:{provider_id}"
+    return merged.get(section, {}).get(dotted_key)
+
+
+def set_project_value(
+    provider_id: str,
+    dotted_key: str,
+    value: str,
+    *,
+    project_file: Optional[Path] = None,
+) -> None:
+    path = project_settings_file(project_file)
+    data = read_sections(path)
+    section = f"provider:{provider_id}"
+    data.setdefault(section, {})[dotted_key] = value
+    write_sections(path, data)
+
+
+def set_user_value(
+    provider_id: str,
+    dotted_key: str,
+    value: str,
+    *,
+    app: Optional[str] = None,
+) -> None:
+    app_name = app or provider_id
+    path = _user_settings_path(app_name)
+    data = read_sections(path)
+    section = f"provider:{provider_id}"
+    data.setdefault(section, {})[dotted_key] = value
+    write_sections(path, data)

--- a/src/pysigil/backend_ini.py
+++ b/src/pysigil/backend_ini.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import configparser
 from pathlib import Path
-from typing import Dict
 
 
 class IniIOError(Exception):
@@ -10,9 +9,9 @@ class IniIOError(Exception):
 
 
 # Returns mapping: section -> mapping(key -> value)
-def read_sections(path: Path) -> Dict[str, Dict[str, str]]:
+def read_sections(path: Path) -> dict[str, dict[str, str]]:
     parser = configparser.ConfigParser(strict=False)
-    data: Dict[str, Dict[str, str]] = {}
+    data: dict[str, dict[str, str]] = {}
     if path.exists():
         try:
             parser.read(path)
@@ -23,7 +22,7 @@ def read_sections(path: Path) -> Dict[str, Dict[str, str]]:
     return data
 
 
-def write_sections(path: Path, data: Dict[str, Dict[str, str]]) -> None:
+def write_sections(path: Path, data: dict[str, dict[str, str]]) -> None:
     parser = configparser.ConfigParser()
     for section in sorted(data):
         parser.add_section(section)

--- a/src/pysigil/backend_ini.py
+++ b/src/pysigil/backend_ini.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+from typing import Dict
+
+
+class IniIOError(Exception):
+    """Raised when an INI file cannot be read or written."""
+
+
+# Returns mapping: section -> mapping(key -> value)
+def read_sections(path: Path) -> Dict[str, Dict[str, str]]:
+    parser = configparser.ConfigParser(strict=False)
+    data: Dict[str, Dict[str, str]] = {}
+    if path.exists():
+        try:
+            parser.read(path)
+        except Exception as exc:  # pragma: no cover - defensive
+            raise IniIOError(str(exc)) from exc
+        for section in parser.sections():
+            data[section] = dict(parser.items(section))
+    return data
+
+
+def write_sections(path: Path, data: Dict[str, Dict[str, str]]) -> None:
+    parser = configparser.ConfigParser()
+    for section in sorted(data):
+        parser.add_section(section)
+        for key, value in sorted(data[section].items()):
+            parser.set(section, key, str(value))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w") as fh:
+        parser.write(fh)
+    tmp.replace(path)

--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -111,8 +111,8 @@ def main(argv: list[str] | None = None) -> int:
             sigil._secrets.unlock()
             return 0
     elif args.cmd == "where":
-        from .keys import parse_key
         from . import metadata
+        from .keys import parse_key
 
         kp = parse_key(args.key)
         meta = metadata.get_meta_for(kp)

--- a/src/pysigil/core.py
+++ b/src/pysigil/core.py
@@ -15,7 +15,6 @@ except ModuleNotFoundError:
     from ._appdirs_stub import user_config_dir
 
 from . import events, metadata
-
 from .backends import get_backend_for_path
 from .constants import KEY_JOIN_CHAR
 from .env import read_env

--- a/src/pysigil/core_defaults.py
+++ b/src/pysigil/core_defaults.py
@@ -1,0 +1,3 @@
+CORE_DEFAULTS = {
+    "pysigil": {"policy": "project_over_user"}
+}

--- a/src/pysigil/defaults.py
+++ b/src/pysigil/defaults.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from importlib.metadata import Distribution
 from pathlib import Path
-from typing import Dict
 
 from .backend_ini import read_sections
 
@@ -11,7 +10,7 @@ class DefaultsFormatError(Exception):
     pass
 
 
-def load_provider_defaults(provider_id: str, dist: Distribution) -> Dict[str, Dict[str, str]]:
+def load_provider_defaults(provider_id: str, dist: Distribution) -> dict[str, dict[str, str]]:
     """Load provider defaults from a distribution.
 
     Parameters
@@ -31,7 +30,7 @@ def load_provider_defaults(provider_id: str, dist: Distribution) -> Dict[str, Di
             raise DefaultsFormatError("provider section name mismatch")
     if expected_section not in data:
         raise DefaultsFormatError("missing provider section")
-    result: Dict[str, Dict[str, str]] = {expected_section: data[expected_section]}
+    result: dict[str, dict[str, str]] = {expected_section: data[expected_section]}
     if "pysigil" in data:
         result["pysigil"] = data["pysigil"]
     return result

--- a/src/pysigil/defaults.py
+++ b/src/pysigil/defaults.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from importlib.metadata import Distribution
+from pathlib import Path
+from typing import Dict
+
+from .backend_ini import read_sections
+
+
+class DefaultsFormatError(Exception):
+    pass
+
+
+def load_provider_defaults(provider_id: str, dist: Distribution) -> Dict[str, Dict[str, str]]:
+    """Load provider defaults from a distribution.
+
+    Parameters
+    ----------
+    provider_id:
+        PEP 503 normalised provider name.
+    dist:
+        Distribution object representing the provider.
+    """
+    cfg_path = Path(dist.locate_file("pysigil/defaults.ini"))
+    if not cfg_path.is_file():
+        return {}
+    data = read_sections(cfg_path)
+    expected_section = f"provider:{provider_id}"
+    for section in data:
+        if section.startswith("provider:") and section != expected_section:
+            raise DefaultsFormatError("provider section name mismatch")
+    if expected_section not in data:
+        raise DefaultsFormatError("missing provider section")
+    result: Dict[str, Dict[str, str]] = {expected_section: data[expected_section]}
+    if "pysigil" in data:
+        result["pysigil"] = data["pysigil"]
+    return result

--- a/src/pysigil/discovery.py
+++ b/src/pysigil/discovery.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from importlib.metadata import entry_points, Distribution
-from typing import Iterator, Tuple
+from collections.abc import Iterator
+from importlib.metadata import Distribution, entry_points
 
 from .provider_id import pep503_name
 
@@ -20,7 +20,7 @@ def _iter_entry_points():
                 yield ep
 
 
-def iter_providers() -> Iterator[Tuple[str, str, Distribution]]:
+def iter_providers() -> Iterator[tuple[str, str, Distribution]]:
     """Yield unique providers discovered via entry points.
 
     Each item is ``(provider_id, display_name, dist)``.  Duplicate provider IDs
@@ -29,7 +29,7 @@ def iter_providers() -> Iterator[Tuple[str, str, Distribution]]:
     seen: set[str] = set()
     for ep in _iter_entry_points():
         dist: Distribution = ep.dist  # type: ignore[attr-defined]
-        name = getattr(dist, "metadata", {}).get("Name") or getattr(dist, "name")
+        name = getattr(dist, "metadata", {}).get("Name") or dist.name
         if not name:
             continue
         provider_id = pep503_name(name)

--- a/src/pysigil/discovery.py
+++ b/src/pysigil/discovery.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from importlib.metadata import entry_points, Distribution
+from typing import Iterator, Tuple
+
+from .provider_id import pep503_name
+
+GROUPS = ("pysigil_providers", "pysigil.providers")
+
+
+def _iter_entry_points():
+    eps = entry_points()
+    if hasattr(eps, "select"):
+        for group in GROUPS:
+            for ep in eps.select(group=group):
+                yield ep
+    else:  # pragma: no cover - legacy API
+        for group in GROUPS:
+            for ep in eps.get(group, []):  # type: ignore[call-arg]
+                yield ep
+
+
+def iter_providers() -> Iterator[Tuple[str, str, Distribution]]:
+    """Yield unique providers discovered via entry points.
+
+    Each item is ``(provider_id, display_name, dist)``.  Duplicate provider IDs
+    are skipped with first-come wins semantics.
+    """
+    seen: set[str] = set()
+    for ep in _iter_entry_points():
+        dist: Distribution = ep.dist  # type: ignore[attr-defined]
+        name = getattr(dist, "metadata", {}).get("Name") or getattr(dist, "name")
+        if not name:
+            continue
+        provider_id = pep503_name(name)
+        if provider_id in seen:
+            continue
+        seen.add(provider_id)
+        yield provider_id, name, dist

--- a/src/pysigil/gui.py
+++ b/src/pysigil/gui.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 import logging
 import os
+from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
@@ -18,7 +18,6 @@ from . import events, gui_state, hub
 from .core import Sigil
 from .keys import KeyPath
 from .widgets import widget_for
-
 
 logger = logging.getLogger("pysigil.gui")
 if os.environ.get("SIGIL_GUI_DEBUG") and not logger.handlers:

--- a/src/pysigil/gui_state.py
+++ b/src/pysigil/gui_state.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 try:
     from appdirs import user_config_dir

--- a/src/pysigil/hub.py
+++ b/src/pysigil/hub.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import inspect
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from threading import Lock
-from typing import Any, Callable, Protocol, runtime_checkable
-#from pyprojroot import here
+from typing import Any, Protocol, runtime_checkable
 
+#from pyprojroot import here
 from .core import Sigil
 from .keys import KeyPath, parse_key
 
@@ -44,7 +45,7 @@ class LaunchGui(Protocol):
 # ---------------------------------------------------------------------------
 
 _lock: threading.Lock = threading.Lock()
-_instances: dict[str | None, "Sigil"] = {}
+_instances: dict[str | None, Sigil] = {}
 
 
 def _find_project_root(start: Path) -> Path:
@@ -115,7 +116,7 @@ def get_preferences(
         Name of the defaults file inside *default_pref_directory*.  Default: 'settings.ini'.
     """
 
-    def _lazy() -> "Sigil":
+    def _lazy() -> Sigil:
         # When a custom defaults directory or settings filename is provided we
         # need to recreate any cached instance for *package* so that callers can
         # override these paths in tests or specialised environments.

--- a/src/pysigil/provider_id.py
+++ b/src/pysigil/provider_id.py
@@ -1,0 +1,8 @@
+import re
+
+_re = re.compile(r"[-_.]+")
+
+
+def pep503_name(dist_name: str) -> str:
+    """Return the PEP 503 normalised project name."""
+    return _re.sub("-", dist_name.strip().lower())

--- a/src/pysigil/resolver.py
+++ b/src/pysigil/resolver.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Project root and settings file resolution utilities."""
+
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_FILENAME = "settings.ini"
+
+class ProjectRootNotFound(RuntimeError):
+    """Raised when no pyproject.toml can be found in parent directories."""
+    pass
+
+
+def find_project_root(start: Optional[Path] = None) -> Path:
+    """Return absolute path to nearest ancestor containing pyproject.toml.
+
+    Parameters
+    ----------
+    start:
+        Starting directory.  If ``None`` the current working directory is used.
+
+    Raises
+    ------
+    ProjectRootNotFound
+        If no ``pyproject.toml`` is found when walking up to the filesystem
+        root.
+    """
+    start_path = Path.cwd() if start is None else Path(start)
+    for candidate in (start_path, *start_path.parents):
+        if (candidate / "pyproject.toml").is_file():
+            return candidate.resolve()
+    raise ProjectRootNotFound(
+        "No pyproject.toml found; provide --project-file or run inside a project"
+    )
+
+
+def project_settings_file(
+    explicit_file: Optional[Path] = None,
+    start: Optional[Path] = None,
+    filename: str = DEFAULT_FILENAME,
+) -> Path:
+    """Resolve the project settings file path.
+
+    If ``explicit_file`` is supplied, its absolute path is returned. Otherwise
+    ``find_project_root`` is used to locate the project root and
+    ``<root>/.pysigil/<filename>`` is returned.  The ``.pysigil`` directory is
+    created if necessary.
+    """
+    if explicit_file is not None:
+        return Path(explicit_file).expanduser().resolve()
+    root = find_project_root(start)
+    cfg_dir = root / ".pysigil"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    return (cfg_dir / filename).resolve()

--- a/src/pysigil/resolver.py
+++ b/src/pysigil/resolver.py
@@ -1,19 +1,17 @@
-from __future__ import annotations
-
 """Project root and settings file resolution utilities."""
 
 from pathlib import Path
-from typing import Optional
 
 DEFAULT_FILENAME = "settings.ini"
 
-class ProjectRootNotFound(RuntimeError):
-    """Raised when no pyproject.toml can be found in parent directories."""
+
+class ProjectRootNotFoundError(RuntimeError):
+    """Raised when no ``pyproject.toml`` can be found in parent directories."""
     pass
 
 
-def find_project_root(start: Optional[Path] = None) -> Path:
-    """Return absolute path to nearest ancestor containing pyproject.toml.
+def find_project_root(start: Path | None = None) -> Path:
+    """Return absolute path to nearest ancestor containing ``pyproject.toml``.
 
     Parameters
     ----------
@@ -22,7 +20,7 @@ def find_project_root(start: Optional[Path] = None) -> Path:
 
     Raises
     ------
-    ProjectRootNotFound
+    ProjectRootNotFoundError
         If no ``pyproject.toml`` is found when walking up to the filesystem
         root.
     """
@@ -30,14 +28,14 @@ def find_project_root(start: Optional[Path] = None) -> Path:
     for candidate in (start_path, *start_path.parents):
         if (candidate / "pyproject.toml").is_file():
             return candidate.resolve()
-    raise ProjectRootNotFound(
+    raise ProjectRootNotFoundError(
         "No pyproject.toml found; provide --project-file or run inside a project"
     )
 
 
 def project_settings_file(
-    explicit_file: Optional[Path] = None,
-    start: Optional[Path] = None,
+    explicit_file: Path | None = None,
+    start: Path | None = None,
     filename: str = DEFAULT_FILENAME,
 ) -> Path:
     """Resolve the project settings file path.

--- a/tests/test_backend_ini_sections.py
+++ b/tests/test_backend_ini_sections.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from pysigil.backend_ini import read_sections, write_sections
+
+
+def test_roundtrip_and_sort(tmp_path: Path):
+    path = tmp_path / "settings.ini"
+    data = {
+        "provider:foo": {"b": "2", "a": "1"},
+        "pysigil": {"policy": "project_over_user"},
+    }
+    write_sections(path, data)
+    first = path.read_text()
+    write_sections(path, data)
+    second = path.read_text()
+    assert first == second  # deterministic order
+    loaded = read_sections(path)
+    assert loaded == {
+        "provider:foo": {"a": "1", "b": "2"},
+        "pysigil": {"policy": "project_over_user"},
+    }
+
+
+def test_last_write_wins(tmp_path: Path):
+    path = tmp_path / "cfg.ini"
+    path.write_text("[pysigil]\npolicy=one\npolicy=two\n")
+    loaded = read_sections(path)
+    assert loaded == {"pysigil": {"policy": "two"}}

--- a/tests/test_defaults_loader.py
+++ b/tests/test_defaults_loader.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from pysigil.defaults import DefaultsFormatError, load_provider_defaults
+
+
+class StubDist(SimpleNamespace):
+    def locate_file(self, path: str) -> Path:
+        return Path(self.base) / path
+
+
+def test_load_provider_defaults_success(tmp_path: Path):
+    dist = StubDist(base=tmp_path)
+    defaults = tmp_path / "pysigil" / "defaults.ini"
+    defaults.parent.mkdir()
+    defaults.write_text("""[provider:foo]\nkey = val\n[pysigil]\npolicy = project_over_user\n""")
+    data = load_provider_defaults("foo", dist)
+    assert data == {
+        "provider:foo": {"key": "val"},
+        "pysigil": {"policy": "project_over_user"},
+    }
+
+
+def test_load_provider_defaults_wrong_section(tmp_path: Path):
+    dist = StubDist(base=tmp_path)
+    defaults = tmp_path / "pysigil" / "defaults.ini"
+    defaults.parent.mkdir()
+    defaults.write_text("""[provider:bar]\nkey=val\n""")
+    with pytest.raises(DefaultsFormatError):
+        load_provider_defaults("foo", dist)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+from pysigil import discovery
+
+
+def test_iter_providers_dedup(monkeypatch):
+    dist1 = SimpleNamespace(metadata={"Name": "My_pkg"})
+    dist2 = SimpleNamespace(metadata={"Name": "my-pkg"})
+    dist3 = SimpleNamespace(metadata={"Name": "Other"})
+    ep1 = SimpleNamespace(dist=dist1)
+    ep2 = SimpleNamespace(dist=dist2)
+    ep3 = SimpleNamespace(dist=dist3)
+
+    class FakeEntryPoints:
+        def select(self, *, group):
+            mapping = {
+                "pysigil_providers": [ep1, ep2],
+                "pysigil.providers": [ep3],
+            }
+            return mapping.get(group, [])
+
+    monkeypatch.setattr(discovery, "entry_points", lambda: FakeEntryPoints())
+    providers = list(discovery.iter_providers())
+    assert providers == [
+        ("my-pkg", "My_pkg", dist1),
+        ("other", "Other", dist3),
+    ]

--- a/tests/test_gui_startup.py
+++ b/tests/test_gui_startup.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 from pysigil import gui
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-import importlib
-import shutil
-import sys
-from pathlib import Path
 
-from pysigil.helpers import make_package_prefs
 
 
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 from pysigil.core import Sigil
 from pysigil.hub import get_preferences
 

--- a/tests/test_merge_policy.py
+++ b/tests/test_merge_policy.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from pathlib import Path
+
+import pytest
+
+from pysigil import api, backend_ini
+
+
+class DummyDist:
+    pass
+
+
+def test_project_over_user(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    root = tmp_path / "proj"
+    (root / "pyproject.toml").parent.mkdir(exist_ok=True)
+    (root / "pyproject.toml").write_text("[project]\nname='x'")
+    proj_file = root / ".pysigil" / "settings.ini"
+
+    monkeypatch.setattr(api, "_find_distribution", lambda pid: DummyDist())
+    monkeypatch.setattr(
+        api,
+        "load_provider_defaults",
+        lambda pid, dist: {f"provider:{pid}": {"ui.theme": "ocean"}},
+    )
+
+    api.set_project_value("pkg", "ui.theme", "desert", project_file=proj_file)
+    api.set_user_value("pkg", "ui.theme", "forest")
+
+    assert (
+        api.get_value("pkg", "ui.theme", project_file=proj_file)
+        == "desert"
+    )
+
+
+def test_user_over_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    root = tmp_path / "proj"
+    (root / "pyproject.toml").parent.mkdir(exist_ok=True)
+    (root / "pyproject.toml").write_text("[project]\nname='x'")
+    proj_file = root / ".pysigil" / "settings.ini"
+
+    backend_ini.write_sections(
+        proj_file,
+        {
+            "pysigil": {"policy": "user_over_project"},
+            "provider:pkg": {"ui.theme": "desert"},
+        },
+    )
+    api.set_user_value("pkg", "ui.theme", "forest")
+    monkeypatch.setattr(api, "_find_distribution", lambda pid: None)
+
+    assert (
+        api.get_value("pkg", "ui.theme", project_file=proj_file)
+        == "forest"
+    )

--- a/tests/test_merge_policy.py
+++ b/tests/test_merge_policy.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-from pathlib import Path
-
 import pytest
 
 from pysigil import api, backend_ini

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from pysigil.core import Sigil, LockedPreferenceError
+from pysigil.core import LockedPreferenceError, Sigil
 from pysigil.keys import parse_key
 
 

--- a/tests/test_provider_id.py
+++ b/tests/test_provider_id.py
@@ -1,4 +1,3 @@
-import pytest
 
 from pysigil.provider_id import pep503_name
 

--- a/tests/test_provider_id.py
+++ b/tests/test_provider_id.py
@@ -1,0 +1,19 @@
+import pytest
+
+from pysigil.provider_id import pep503_name
+
+
+def test_pep503_normalisation_examples():
+    cases = {
+        "Accio_Data": "accio-data",
+        "my.package": "my-package",
+        "cool-pkg": "cool-pkg",
+    }
+    for inp, expected in cases.items():
+        assert pep503_name(inp) == expected
+
+
+def test_pep503_collisions():
+    names = ["a.b", "a-b", "a_b"]
+    normalised = {pep503_name(n) for n in names}
+    assert normalised == {"a-b"}

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -15,7 +15,7 @@ def test_find_project_root_success(tmp_path: Path):
 
 
 def test_find_project_root_failure(tmp_path: Path):
-    with pytest.raises(resolver.ProjectRootNotFound):
+    with pytest.raises(resolver.ProjectRootNotFoundError):
         resolver.find_project_root(tmp_path)
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import pytest
+
+from pysigil import resolver
+
+
+def test_find_project_root_success(tmp_path: Path):
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\n")
+    sub = root / "sub" / "pkg"
+    sub.mkdir(parents=True)
+    assert resolver.find_project_root(sub) == root
+
+
+def test_find_project_root_failure(tmp_path: Path):
+    with pytest.raises(resolver.ProjectRootNotFound):
+        resolver.find_project_root(tmp_path)
+
+
+def test_project_settings_file_creation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\n")
+    monkeypatch.chdir(root)
+    path = resolver.project_settings_file()
+    assert path == root / ".pysigil" / resolver.DEFAULT_FILENAME
+    assert path.parent.is_dir()

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -2,12 +2,8 @@ from __future__ import annotations
 
 import sys
 import types
-from pathlib import Path
 
-import pytest
-
-from pysigil.errors import SigilSecretsError
-from pysigil.secrets import EncryptedFileProvider, EnvSecretProvider, KeyringProvider
+from pysigil.secrets import EnvSecretProvider, KeyringProvider
 
 
 def test_keyring_roundtrip(monkeypatch):


### PR DESCRIPTION
## Summary
- add project root resolver using pyproject.toml and canonical .pysigil settings
- introduce PEP503 provider IDs, provider discovery, and sectioned INI backend
- load provider defaults from wheels and expose get/set API with policy-aware merge

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897baedbe388328babda2deeddac45a