### PR TITLE
Normalize provider IDs for settings file sections

### DIFF
--- a/src/pysigil/api.py
+++ b/src/pysigil/api.py
@@ -47,6 +47,7 @@ def get_value(
     project_file: Path | None = None,
     app: str | None = None,
 ) -> str | None:
+    provider_id = pep503_name(provider_id)
     app_name = app or provider_id
     project_path = project_settings_file(project_file)
     user_path = _user_settings_path(app_name)
@@ -87,6 +88,7 @@ def set_project_value(
     *,
     project_file: Path | None = None,
 ) -> None:
+    provider_id = pep503_name(provider_id)
     path = project_settings_file(project_file)
     data = read_sections(path)
     section = f"provider:{provider_id}"
@@ -101,6 +103,7 @@ def set_user_value(
     *,
     app: str | None = None,
 ) -> None:
+    provider_id = pep503_name(provider_id)
     app_name = app or provider_id
     path = _user_settings_path(app_name)
     data = read_sections(path)

--- a/tests/test_api_normalization.py
+++ b/tests/test_api_normalization.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from pysigil import api, backend_ini
+
+def test_set_creates_project_file_and_normalizes_provider(tmp_path, monkeypatch):
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\n")
+    monkeypatch.chdir(root)
+
+    api.set_project_value("My.Package", "ui.theme", "forest")
+
+    cfg = root / ".pysigil" / "settings.ini"
+    data = backend_ini.read_sections(cfg)
+    assert data == {"provider:my-package": {"ui.theme": "forest"}}
+    assert api.get_value("My.Package", "ui.theme") == "forest"


### PR DESCRIPTION
## Summary
- ensure API functions normalize provider IDs using PEP 503 rules before reading or writing settings
- add regression test confirming `.pysigil/settings.ini` is created with normalized provider section

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d028d706083288dd1bf88c7f427fc