### PR TITLE
Restore GUI and CLI integration

### DIFF
--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -42,6 +42,11 @@ def build_parser(prog: str = "sigil") -> argparse.ArgumentParser:
     export_p.add_argument("--prefix", default="SIGIL_")
     export_p.add_argument("--json", action="store_true")
 
+    gui_p = sub.add_parser("gui")
+    gui_p.add_argument("--app")
+    gui_p.add_argument("--include-sigil", action="store_true")
+    gui_p.add_argument("--no-remember", action="store_true")
+
     return parser
 
 
@@ -52,7 +57,8 @@ def main(argv: list[str] | None = None) -> int:
         prog = "pysigil"
     parser = build_parser(prog)
     args = parser.parse_args(argv)
-    sigil = Sigil(args.app)
+    if args.cmd != "gui":
+        sigil = Sigil(args.app)
     if args.cmd == "get":
         val = sigil.get_pref(args.key)
         if val is None:
@@ -91,6 +97,15 @@ def main(argv: list[str] | None = None) -> int:
         elif args.scmd == "unlock":
             sigil._secrets.unlock()
             return 0
+    elif args.cmd == "gui":
+        from .gui import launch_gui
+
+        launch_gui(
+            package=args.app,
+            include_sigil=args.include_sigil,
+            remember_state=not args.no_remember,
+        )
+        return 0
     return 1
 
 

--- a/src/pysigil/core.py
+++ b/src/pysigil/core.py
@@ -8,12 +8,10 @@ from pathlib import Path
 from threading import RLock
 from typing import Any
 
+from . import events
 from .errors import (
     ReadOnlyScopeError,
-    SigilError,
-    SigilLoadError,
-    SigilMetaError,
-    SigilSecretsError,
+    SigilError,  # noqa: F401 - re-exported for compatibility
     SigilWriteError,
     UnknownScopeError,
 )
@@ -339,6 +337,7 @@ class Sigil:
             backend = _backend_for(path_file)
             backend.save(path_file, data)
             self.invalidate_cache()
+        events.emit("pref_changed", dotted, str(value) if value is not None else None, target_scope)
 
     def _get_scope_storage(self, scope: str) -> tuple[MutableMapping[KeyPath, str], Path]:
         if scope == "user":

--- a/src/pysigil/events.py
+++ b/src/pysigil/events.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable
+from typing import Any
+
+_handlers: defaultdict[str, list[Callable[..., Any]]] = defaultdict(list)
+
+
+def on(event: str, callback: Callable[..., Any]) -> None:
+    _handlers[event].append(callback)
+
+
+def emit(event: str, *args: Any, **kwargs: Any) -> None:
+    for callback in list(_handlers.get(event, [])):
+        callback(*args, **kwargs)
+
+
+__all__ = ["on", "emit"]

--- a/src/pysigil/gui.py
+++ b/src/pysigil/gui.py
@@ -16,7 +16,7 @@ except Exception:  # pragma: no cover - fallback for headless tests
 
 from . import events, gui_state, hub
 from .core import Sigil
-from .keys import KeyPath
+from .merge_policy import KeyPath
 from .widgets import widget_for
 
 logger = logging.getLogger("pysigil.gui")
@@ -32,6 +32,19 @@ if os.environ.get("SIGIL_GUI_DEBUG") and not logger.handlers:
 
 _sigil_instance: Sigil | None = None
 _current_package: str | None = None
+
+
+class SigilGUI:
+    """Legacy wrapper used in tests to ensure GUI can be instantiated."""
+
+    def __init__(self, sigil: Sigil) -> None:
+        if tk is None or ttk is None:  # pragma: no cover - tkinter missing
+            raise RuntimeError("tkinter is required for GUI mode")
+        self.sigil = sigil
+        try:
+            self.root = tk.Tk()
+        except Exception as exc:  # pragma: no cover - no display
+            raise RuntimeError(str(exc)) from exc
 
 
 def open_package(package: str, include_sigil: bool) -> None:
@@ -371,6 +384,7 @@ def launch_gui(
 
 
 __all__ = [
+    "SigilGUI",
     "open_package",
     "current_keys",
     "effective_scope_for",

--- a/src/pysigil/gui_state.py
+++ b/src/pysigil/gui_state.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from collections.abc import MutableMapping
+from pathlib import Path
+from typing import Any
+
+DEFAULT_PATH = Path.home() / ".config" / "sigil" / "gui_state.json"
+
+
+def read_state(path: Path | None = None) -> MutableMapping[str, Any]:
+    path = path or DEFAULT_PATH
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+
+def write_state(state: MutableMapping[str, Any], path: Path | None = None) -> None:
+    path = path or DEFAULT_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state))
+
+
+__all__ = ["read_state", "write_state"]

--- a/src/pysigil/hub.py
+++ b/src/pysigil/hub.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .core import Sigil
+
+_instances: dict[str, Sigil] = {}
+
+
+def get_preferences(package: str) -> tuple[Callable[..., object], Callable[..., object], Sigil]:
+    sig = _instances.get(package)
+    if sig is None:
+        sig = Sigil(package)
+        _instances[package] = sig
+    return sig.get_pref, sig.set_pref, sig
+
+
+__all__ = ["get_preferences", "_instances"]

--- a/src/pysigil/widgets.py
+++ b/src/pysigil/widgets.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+try:
+    import tkinter as tk
+    from tkinter import ttk
+except Exception:  # pragma: no cover - fallback when tkinter missing
+    tk = None  # type: ignore
+    ttk = None  # type: ignore
+
+
+def widget_for(key: str, value: str | None, master):
+    if ttk is None or tk is None:  # pragma: no cover - no tkinter available
+        raise RuntimeError("tkinter is required for widgets")
+    entry = ttk.Entry(master)
+
+    def _set(val: str | None) -> None:
+        entry.delete(0, tk.END)
+        if val is not None:
+            entry.insert(0, val)
+
+    entry.set = _set  # type: ignore[attr-defined]
+    return entry
+
+
+__all__ = ["widget_for"]


### PR DESCRIPTION
## Summary
- Reintroduce GUI helpers with new modules for events, GUI state, hub, and widgets
- Emit `pref_changed` events and provide legacy `SigilGUI` wrapper
- Add `sigil gui` subcommand to launch the GUI from the CLI

## Testing
- `ruff check src/pysigil/cli.py src/pysigil/core.py src/pysigil/gui.py src/pysigil/events.py src/pysigil/gui_state.py src/pysigil/hub.py src/pysigil/widgets.py`
- `pytest -q`
- `python -m pysigil.cli gui --help`


------
https://chatgpt.com/codex/tasks/task_e_689d12400428832886f8e575d9dbf5e8