### PR TITLE
Fix GUI updates for new preferences

### DIFF
--- a/src/pysigil/gui/__init__.py
+++ b/src/pysigil/gui/__init__.py
@@ -186,7 +186,8 @@ def _on_delete(widgets: dict) -> None:
 def _on_pref_changed(widgets: dict, key: str, new_val: str | None, scope: str) -> None:
     logger.debug("pref_changed %s=%s scope=%s", key, new_val, scope)
     tree = widgets["trees"].get(scope)
-    if tree is None:
+    empty = widgets.get("empty_labels", {}).get(scope)
+    if tree is None or empty is None:
         return
     if new_val is None:
         if tree.exists(key):
@@ -196,6 +197,12 @@ def _on_pref_changed(widgets: dict, key: str, new_val: str | None, scope: str) -
             tree.item(key, values=(key, new_val))
         else:
             tree.insert("", "end", iid=key, values=(key, new_val))
+    if tree.get_children():
+        empty.pack_forget()
+        tree.pack(fill="both", expand=True)
+    else:
+        tree.pack_forget()
+        empty.pack(fill="both", expand=True)
 
 
 # ---------------------------------------------------------------------------
@@ -345,7 +352,7 @@ def launch_gui(
 
     _refresh()
 
-    widgets = {"notebook": notebook, "trees": trees}
+    widgets = {"notebook": notebook, "trees": trees, "empty_labels": empty_labels}
     button_bar = ttk.Frame(root)
     button_bar.pack(fill="x", padx=4, pady=4)
     ttk.Button(button_bar, text="Add", command=lambda: _on_add(widgets)).pack(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pysigil.core import KEY_JOIN_CHAR, Sigil
+from pysigil.gui import _on_pref_changed, events
+
+
+class DummyTree:
+    def __init__(self) -> None:
+        self.items: dict[str, tuple[str, str]] = {}
+        self.packed = False
+
+    def exists(self, iid: str) -> bool:
+        return iid in self.items
+
+    def item(self, iid: str, values: tuple[str, str] | None = None):
+        if values is not None:
+            self.items[iid] = values
+        return self.items.get(iid)
+
+    def insert(self, parent: str, index: str, iid: str, values: tuple[str, str]):
+        self.items[iid] = values
+
+    def delete(self, iid: str) -> None:
+        self.items.pop(iid, None)
+
+    def get_children(self) -> list[str]:
+        return list(self.items.keys())
+
+    def pack(self, **_kwargs) -> None:
+        self.packed = True
+
+    def pack_forget(self) -> None:
+        self.packed = False
+
+
+class DummyLabel:
+    def __init__(self) -> None:
+        self.packed = False
+
+    def pack(self, **_kwargs) -> None:
+        self.packed = True
+
+    def pack_forget(self) -> None:
+        self.packed = False
+
+
+def test_pref_changed_event_uses_join_char(tmp_path):
+    events._handlers.clear()
+    sigil = Sigil("demo", user_scope=tmp_path)
+    received: list[str] = []
+
+    def _cb(k, _v, _s):
+        received.append(k)
+
+    events.on("pref_changed", _cb)
+    sigil.set_pref("foo.bar", "baz", scope="user")
+    assert received == [f"foo{KEY_JOIN_CHAR}bar"]
+
+
+def test_on_pref_changed_updates_empty_label():
+    tree = DummyTree()
+    label = DummyLabel()
+    widgets = {"trees": {"user": tree}, "empty_labels": {"user": label}}
+
+    _on_pref_changed(widgets, "foo", "bar", "user")
+    assert tree.packed is True
+    assert label.packed is False
+
+    _on_pref_changed(widgets, "foo", None, "user")
+    assert tree.packed is False
+    assert label.packed is True
+


### PR DESCRIPTION
## Summary
- ensure pref_changed events use underscores to match tree keys
- show newly-added preferences immediately by toggling empty labels
- cover pref_changed events with tests

## Testing
- `ruff check src/pysigil/core.py src/pysigil/gui/__init__.py tests/test_events.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d1a0610908328ae643a099973e776