### PR TITLE
Enable writing default scope preferences

### DIFF
--- a/src/pysigil/core.py
+++ b/src/pysigil/core.py
@@ -389,7 +389,18 @@ class Sigil:
             return self._user, self.user_path
         if scope == "project":
             return self._project, self.project_path
-        if scope == "default" and self.default_path is not None:
+        if scope == "default":
+            if self.default_path is None:
+                # Lazily resolve a path for the default scope.  If the package
+                # cannot be located fall back to a ``prefs`` directory under
+                # the current working directory so that callers can still
+                # create defaults for arbitrary packages.
+                path = package_defaults_file(
+                    self.app_name, filename=self.settings_filename
+                )
+                if path is None:
+                    path = Path.cwd() / "prefs" / self.settings_filename
+                self.default_path = path
             return self._defaults, self.default_path
         raise UnknownScopeError(scope)
 

--- a/src/pysigil/resolver.py
+++ b/src/pysigil/resolver.py
@@ -72,10 +72,12 @@ def user_settings_file(app_name: str, filename: str = DEFAULT_FILENAME) -> Path:
 def package_defaults_file(
     package: str, filename: str = DEFAULT_DEFAULTS_FILENAME
 ) -> Path | None:
-    """Return path to a package's bundled defaults file if present.
+    """Return path to a package's bundled defaults file.
 
-    The function looks for ``prefs/<filename>`` within the installed package and
-    returns ``None`` if no such resource exists.
+    The path points to ``prefs/<filename>`` within the installed package.  If
+    the package itself cannot be located ``None`` is returned.  The defaults
+    file does not need to exist yet; callers may create it to enable writes to
+    the ``"default"`` scope.
     """
 
     try:
@@ -83,7 +85,5 @@ def package_defaults_file(
     except ModuleNotFoundError:  # pragma: no cover - defensive
         return None
     candidate = pkg_root / "prefs" / filename
-    if candidate.exists():
-        return Path(candidate).resolve()
-    return None
+    return Path(candidate).resolve()
 

--- a/tests/test_core_basic.py
+++ b/tests/test_core_basic.py
@@ -10,3 +10,29 @@ def test_roundtrip(tmp_path: Path) -> None:
     content = (tmp_path / "settings.ini").read_text()
     assert "[demo]" in content
     assert "foo_bar = baz" in content
+
+
+def test_default_roundtrip(tmp_path: Path) -> None:
+    user_dir = tmp_path / "user"
+    default_file = tmp_path / "defaults.ini"
+    s = Sigil(
+        "demo",
+        user_scope=user_dir,
+        default_path=default_file,
+        settings_filename="defaults.ini",
+    )
+    s.set_pref("foo.bar", "baz", scope="default")
+    assert s.get_pref("foo.bar") == "baz"
+    content = default_file.read_text()
+    assert "[demo]" in content
+    assert "foo_bar = baz" in content
+
+
+def test_default_roundtrip_fallback(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    s = Sigil("no_pkg")
+    s.set_pref("alpha.beta", "42", scope="default")
+    assert s.get_pref("alpha.beta") == 42
+    cfg = tmp_path / "prefs" / "settings.ini"
+    assert cfg.exists()
+    assert "alpha_beta = 42" in cfg.read_text()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -36,3 +36,13 @@ def test_package_defaults_file(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.syspath_prepend(tmp_path)
     path = package_defaults_file("pkg", filename="settings.ini")
     assert path == pkg / "prefs" / "settings.ini"
+
+
+def test_package_defaults_file_missing(tmp_path: Path, monkeypatch) -> None:
+    pkg = tmp_path / "pkg_missing"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    monkeypatch.syspath_prepend(tmp_path)
+    path = package_defaults_file("pkg_missing", filename="settings.ini")
+    assert path == pkg / "prefs" / "settings.ini"
+    assert not path.exists()


### PR DESCRIPTION
## Summary
- allow `package_defaults_file` to return a writable path even when missing
- add regression tests for default-scope writes and package default path resolution
- support writing default preferences even when package cannot be located by falling back to `./prefs/<filename>`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d1cebe0408328b36c19ad3926ed75