### PR TITLE
Load read-only defaults from package `.sigil` settings

### DIFF
--- a/src/pysigil/resolver.py
+++ b/src/pysigil/resolver.py
@@ -7,7 +7,6 @@ from appdirs import user_config_dir
 from pyprojroot import here
 
 DEFAULT_FILENAME = "settings.ini"
-DEFAULT_DEFAULTS_FILENAME = "defaults.ini"
 
 
 class ProjectRootNotFoundError(RuntimeError):
@@ -45,7 +44,7 @@ def project_settings_file(
 
     If ``explicit_file`` is supplied, its absolute path is returned. Otherwise
     :func:`find_project_root` is used to locate the project root and
-    ``<root>/.pysigil/<filename>`` is returned.  The ``.pysigil`` directory is
+    ``<root>/.sigil/<filename>`` is returned.  The ``.sigil`` directory is
     created if necessary.
     """
 
@@ -70,20 +69,19 @@ def user_settings_file(app_name: str, filename: str = DEFAULT_FILENAME) -> Path:
 
 
 def package_defaults_file(
-    package: str, filename: str = DEFAULT_DEFAULTS_FILENAME
+    package: str, filename: str = DEFAULT_FILENAME
 ) -> Path | None:
     """Return path to a package's bundled defaults file.
 
-    The path points to ``prefs/<filename>`` within the installed package.  If
-    the package itself cannot be located ``None`` is returned.  The defaults
-    file does not need to exist yet; callers may create it to enable writes to
-    the ``"default"`` scope.
+    The path points to ``.sigil/<filename>`` within the installed package.  If
+    the package itself cannot be located ``None`` is returned.  The resulting
+    file is considered read-only and should not be modified at runtime.
     """
 
     try:
         pkg_root = resources.files(package)
     except ModuleNotFoundError:  # pragma: no cover - defensive
         return None
-    candidate = pkg_root / "prefs" / filename
+    candidate = pkg_root / ".sigil" / filename
     return Path(candidate).resolve()
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -24,18 +24,18 @@ def test_project_settings_file(tmp_path: Path) -> None:
     sub = tmp_path / "src"
     sub.mkdir()
     path = project_settings_file(start=sub)
-    assert path == tmp_path / ".pysigil" / "settings.ini"
+    assert path == tmp_path / ".sigil" / "settings.ini"
     assert path.parent.is_dir()
 
 
 def test_package_defaults_file(tmp_path: Path, monkeypatch) -> None:
     pkg = tmp_path / "pkg"
-    (pkg / "prefs").mkdir(parents=True)
-    (pkg / "prefs" / "settings.ini").write_text("[pkg]\nfoo=bar\n")
+    (pkg / ".sigil").mkdir(parents=True)
+    (pkg / ".sigil" / "settings.ini").write_text("[pkg]\nfoo=bar\n")
     (pkg / "__init__.py").write_text("")
     monkeypatch.syspath_prepend(tmp_path)
     path = package_defaults_file("pkg", filename="settings.ini")
-    assert path == pkg / "prefs" / "settings.ini"
+    assert path == pkg / ".sigil" / "settings.ini"
 
 
 def test_package_defaults_file_missing(tmp_path: Path, monkeypatch) -> None:
@@ -44,5 +44,5 @@ def test_package_defaults_file_missing(tmp_path: Path, monkeypatch) -> None:
     (pkg / "__init__.py").write_text("")
     monkeypatch.syspath_prepend(tmp_path)
     path = package_defaults_file("pkg_missing", filename="settings.ini")
-    assert path == pkg / "prefs" / "settings.ini"
+    assert path == pkg / ".sigil" / "settings.ini"
     assert not path.exists()


### PR DESCRIPTION
## Summary
- Load packaged defaults from `.sigil/settings.ini` and mark them as read-only
- Prevent writing to the default scope in `Sigil`
- Support provider defaults in standard settings format

## Testing
- `pytest -q`
- `pre-commit run --files src/pysigil/core.py src/pysigil/io_config.py src/pysigil/resolver.py tests/test_core_basic.py tests/test_resolver.py` *(fails: command not found, installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689d327f64c08328b2be6b0486389a7c