### PR TITLE
Add author registration CLI and GUI

### DIFF
--- a/AUTHORS_GUIDE.md
+++ b/AUTHORS_GUIDE.md
@@ -1,0 +1,95 @@
+# Sigil – Author Registration Guide
+
+This guide shows package authors how to register their package defaults so Sigil can find them **during development** (without installing the package).
+
+## What you’re doing (in one sentence)
+Creating a small dev-link file under your user config (e.g. `~/.config/sigil/dev/<provider>.ini`) that points to your package’s `.sigil/settings.ini`.
+
+## Prereqs
+- Your package repository contains `.sigil/settings.ini` next to your `__init__.py` (e.g. `my_pkg/.sigil/settings.ini`).
+- You installed Sigil with the CLI/GUI:
+  ```bash
+  pip install sigil  # or your editable install
+  ```
+
+## Provider ID
+
+We use your **PEP 503 normalized** distribution name as the provider id (lowercase; runs of `-_.` become `-`). Examples:
+
+* `My_Package.Name` → `my-package-name`
+* `awesome.pkg` → `awesome-pkg`
+
+## Option A — CLI (Click)
+
+Register a dev link:
+
+```bash
+sigil author register --provider my-package \
+  --defaults /abs/path/to/my_pkg/.sigil/settings.ini
+```
+
+If you want to skip shape validation (not recommended):
+
+```bash
+sigil author register --provider my-package --defaults /path/to/settings.ini --no-validate
+```
+
+List and inspect links:
+
+```bash
+sigil author list
+sigil author list --existing-only  # hide missing targets
+```
+
+Remove a link:
+
+```bash
+sigil author unlink-defaults my-package
+```
+
+## Option B — GUI (Tkinter)
+
+Launch the GUI wizard:
+
+```bash
+sigil-gui
+```
+
+Steps:
+
+1. Click **Browse…** and choose your `.sigil/settings.ini`.
+2. Confirm the suggested provider id (edit if you like; it will be normalized when saved).
+3. Click **Register**. A success message will show the link destination.
+4. (Optional) **Open dev-links folder** to verify the file was created.
+
+## Where does Sigil store the link?
+
+* **Windows**: `%APPDATA%/sigil/dev/<provider>.ini`
+* **macOS**: `~/Library/Application Support/sigil/dev/<provider>.ini`
+* **Linux**: `~/.config/sigil/dev/<provider>.ini`
+
+Each link file is a tiny INI like:
+
+```ini
+[link]
+defaults=/abs/path/to/my_pkg/.sigil/settings.ini
+```
+
+## Packaging tip
+
+When you publish, include `.sigil/settings.ini` in your wheel:
+
+```toml
+# pyproject.toml (example)
+[tool.setuptools.package-data]
+"my_pkg" = [".sigil/settings.ini"]
+```
+
+## Troubleshooting
+
+* **“Defaults file must be inside a '.sigil' directory.”**
+  Ensure the file is literally named `settings.ini` and lives under a folder named `.sigil`.
+* **“No dev link found” when unlinking**
+  Run `sigil author list` to see what’s registered; check for normalization (`my-package` vs `my_package`).
+* **Path shows (missing)** in `list`
+  Move/restore the target file or re-register with the new absolute path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ secrets-crypto = ["keyring>=25", "cryptography>=42"]
 [project.scripts]
 sigil = "pysigil.cli:main"
 pysigil = "pysigil.cli:main"
-sigil-gui = "pysigil.gui:launch_gui"
+sigil-gui = "pysigil.gui.author:main"
 
 [tool.ruff]
 line-length = 88

--- a/src/pysigil/gui/author.py
+++ b/src/pysigil/gui/author.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import os
+import sys
+import webbrowser
+from pathlib import Path
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+from ..authoring import DevLinkError, _dev_dir, link, normalize_provider_id
+
+APP_TITLE = "Sigil – Register Package Defaults"
+
+
+class RegisterApp(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title(APP_TITLE)
+        self.geometry("640x320")
+        self.minsize(520, 280)
+
+        self.defaults_path: tk.StringVar = tk.StringVar(value="")
+        self.provider_id: tk.StringVar = tk.StringVar(value="")
+        self.message_var: tk.StringVar = tk.StringVar(
+            value="Pick your .sigil/settings.ini and confirm the provider id."
+        )
+
+        self._build()
+
+    def _build(self) -> None:
+        pad = {"padx": 12, "pady": 8}
+
+        frm = ttk.Frame(self)
+        frm.pack(fill=tk.BOTH, expand=True)
+
+        row1 = ttk.Frame(frm)
+        row1.pack(fill=tk.X, **pad)
+        ttk.Label(row1, text="1) Defaults file (.sigil/settings.ini):").pack(anchor=tk.W)
+
+        pick = ttk.Frame(row1)
+        pick.pack(fill=tk.X)
+        entry = ttk.Entry(pick, textvariable=self.defaults_path)
+        entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        ttk.Button(pick, text="Browse…", command=self.on_browse).pack(side=tk.LEFT, padx=6)
+
+        row2 = ttk.Frame(frm)
+        row2.pack(fill=tk.X, **pad)
+        ttk.Label(row2, text="2) Provider ID (PEP 503 normalized):").pack(anchor=tk.W)
+        prov = ttk.Entry(row2, textvariable=self.provider_id)
+        prov.pack(fill=tk.X)
+
+        actions = ttk.Frame(frm)
+        actions.pack(fill=tk.X, **pad)
+        ttk.Button(actions, text="Register", command=self.on_register).pack(side=tk.LEFT)
+        ttk.Button(actions, text="Open dev-links folder", command=self.on_open_folder).pack(
+            side=tk.LEFT, padx=8
+        )
+        ttk.Button(actions, text="Quit", command=self.destroy).pack(side=tk.RIGHT)
+
+        status = ttk.Frame(self)
+        status.pack(fill=tk.X)
+        ttk.Label(status, textvariable=self.message_var).pack(anchor=tk.W, padx=10, pady=6)
+
+    def on_browse(self) -> None:
+        fn = filedialog.askopenfilename(
+            title="Select .sigil/settings.ini",
+            filetypes=[("INI files", "*.ini"), ("All files", "*.*")],
+        )
+        if not fn:
+            return
+        p = Path(fn)
+        self.defaults_path.set(str(p))
+        try:
+            pkg_dir = p.parent.parent.name
+            self.provider_id.set(normalize_provider_id(pkg_dir))
+        except Exception:
+            self.provider_id.set(normalize_provider_id(p.stem))
+
+    def on_register(self) -> None:
+        defaults = Path(self.defaults_path.get().strip())
+        provider = self.provider_id.get().strip()
+
+        if not defaults:
+            messagebox.showerror("Missing file", "Please choose your .sigil/settings.ini file.")
+            return
+        if not provider:
+            messagebox.showerror("Missing provider id", "Please enter a provider id.")
+            return
+
+        try:
+            dl = link(provider, defaults, validate=True)
+            self.message_var.set(f"Linked {dl.provider_id} -> {dl.defaults_path}")
+            messagebox.showinfo(
+                "Success", f"Registered defaults for {dl.provider_id}.\n\n{dl.defaults_path}"
+            )
+        except DevLinkError as e:
+            self.message_var.set(str(e))
+            messagebox.showerror("Error", str(e))
+
+    def on_open_folder(self) -> None:
+        folder = _dev_dir()
+        folder.mkdir(parents=True, exist_ok=True)
+        if sys.platform.startswith("win"):
+            os.startfile(folder)  # type: ignore[attr-defined]
+        elif sys.platform == "darwin":
+            os.system(f"open '{folder}'")
+        else:
+            try:
+                os.system(f"xdg-open '{folder}'")
+            except Exception:
+                webbrowser.open(str(folder))
+
+
+def main() -> None:
+    app = RegisterApp()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pysigil/resolver.py
+++ b/src/pysigil/resolver.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from appdirs import user_config_dir
 from pyprojroot import here
 
-from .authoring import load_links
+from .authoring import get as get_dev_link
 
 DEFAULT_FILENAME = "settings.ini"
 
@@ -113,10 +113,9 @@ def resolve_defaults(provider_id: str, filename: str = DEFAULT_FILENAME) -> tupl
     path = _installed_defaults(provider_id, filename)
     if path is not None and path.is_file():
         return path, "installed"
-    links = load_links()
-    link_path = links.get(provider_id)
-    if link_path and link_path.is_file():
-        return link_path, "dev-link"
+    dl = get_dev_link(provider_id)
+    if dl and dl.defaults_path.is_file():
+        return dl.defaults_path, "dev-link"
     # Fallback to importable package for legacy/dev usage
     pkg_path = package_defaults_file(provider_id, filename)
     if pkg_path is not None and pkg_path.is_file():


### PR DESCRIPTION
## Summary
- move author registration CLI into existing pysigil CLI module
- integrate dev link management into authoring utilities
- expose Tkinter-based author registration GUI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e687ed0648328ba0e04e75ee5d2b6