### PR TITLE
Refactor CLI to use Click and add author GUI command

### DIFF
--- a/AUTHORS_GUIDE.md
+++ b/AUTHORS_GUIDE.md
@@ -52,7 +52,7 @@ sigil author unlink-defaults my-package
 Launch the GUI wizard:
 
 ```bash
-sigil-gui
+sigil setup
 ```
 
 Steps:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ pysigil ships with a simple graphical editor for viewing and editing
 preferences. After installation launch it with:
 
 ```bash
-sigil-gui
+sigil gui
+```
+
+Package authors can register development defaults via:
+
+```bash
+sigil setup
 ```
 
 Or launch it programmatically:

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -4,7 +4,7 @@ Sigil ships with a small Tk based GUI for editing user preferences. Install with
 `pip install sigil[gui]` and run:
 
 ```
-sigil-gui --app myapp
+sigil gui --app myapp
 ```
 
 Alternatively, launch it from Python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ description = "Preferences & secrets manager with layered scopes and tuple-key i
 readme = "README.md"
 requires-python = ">=3.10"
 version = "0.2.0"
-dependencies = ["appdirs", "tomlkit"]
+dependencies = ["appdirs", "tomlkit", "click"]
 authors = [{ name = "Tim Marquart" }]
 
 [project.optional-dependencies]
@@ -26,9 +26,8 @@ secrets = ["keyring>=25"]
 secrets-crypto = ["keyring>=25", "cryptography>=42"]
 
 [project.scripts]
-sigil = "pysigil.cli:main"
-pysigil = "pysigil.cli:main"
-sigil-gui = "pysigil.gui.author:main"
+sigil = "pysigil.cli:cli"
+pysigil = "pysigil.cli:cli"
 
 [tool.ruff]
 line-length = 88

--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-import argparse
+import json
 import os
 import sys
 from pathlib import Path
+
+import click
 
 from .authoring import (
     DefaultsValidationError,
@@ -20,74 +22,6 @@ from .discovery import pep503_name
 from .gui import launch_gui
 
 
-def build_parser(prog: str = "sigil") -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog=prog)
-    sub = parser.add_subparsers(dest="cmd", required=True)
-
-    get_p = sub.add_parser("get")
-    get_p.add_argument("key")
-    get_p.add_argument("--app", required=True)
-
-    set_p = sub.add_parser("set")
-    set_p.add_argument("key")
-    set_p.add_argument("value")
-    set_p.add_argument("--app", required=True)
-    set_p.add_argument("--scope", choices=["user", "project"], default="user")
-
-    secret_p = sub.add_parser("secret")
-    secret_sub = secret_p.add_subparsers(dest="scmd", required=True)
-
-    sec_get = secret_sub.add_parser("get")
-    sec_get.add_argument("key")
-    sec_get.add_argument("--app", required=True)
-    sec_get.add_argument("--reveal", action="store_true")
-
-    sec_set = secret_sub.add_parser("set")
-    sec_set.add_argument("key")
-    sec_set.add_argument("value")
-    sec_set.add_argument("--app", required=True)
-
-    sec_unlock = secret_sub.add_parser("unlock")
-    sec_unlock.add_argument("--app", required=True)
-
-    export_p = sub.add_parser("export")
-    export_p.add_argument("--app", required=True)
-    export_p.add_argument("--prefix", default="SIGIL_")
-    export_p.add_argument("--json", action="store_true")
-
-    gui_p = sub.add_parser("gui")
-    gui_p.add_argument("--app")
-    gui_p.add_argument("--include-sigil", action="store_true")
-    gui_p.add_argument("--no-remember", action="store_true")
-
-    auth_p = sub.add_parser("author")
-    auth_sub = auth_p.add_subparsers(dest="acmd", required=True)
-
-    reg_p = auth_sub.add_parser("register")
-    reg_p.add_argument("--provider", required=True)
-    reg_p.add_argument("--defaults", required=True)
-    reg_p.add_argument("--add-package-data", action="store_true")
-    reg_p.add_argument("--pyproject")
-    reg_p.add_argument("--no-dev-link", action="store_true")
-    reg_p.add_argument("--yes", action="store_true")
-
-    link_p = auth_sub.add_parser("link-defaults")
-    link_p.add_argument("provider_id")
-    link_p.add_argument("path")
-
-    unlink_p = auth_sub.add_parser("unlink-defaults")
-    unlink_p.add_argument("provider_id")
-
-    val_p = auth_sub.add_parser("validate")
-    val_p.add_argument("provider_id")
-    val_p.add_argument("path")
-
-    list_p = auth_sub.add_parser("list")
-    list_p.add_argument("--existing-only", action="store_true")
-
-    return parser
-
-
 def _find_pyproject(start: Path) -> Path | None:
     for parent in [start, *start.parents]:
         candidate = parent / "pyproject.toml"
@@ -96,115 +30,221 @@ def _find_pyproject(start: Path) -> Path | None:
     return None
 
 
+@click.group()
+def cli() -> None:
+    """Sigil command line interface."""
+
+
+# ---------------------------------------------------------------------------
+# Basic commands
+# ---------------------------------------------------------------------------
+
+
+@cli.command()
+@click.argument("key")
+@click.option("--app", required=True)
+def get(app: str, key: str) -> None:
+    """Print the value for KEY."""
+
+    sigil = Sigil(app)
+    val = sigil.get_pref(key)
+    if val is None:
+        raise click.exceptions.Exit(1)
+    click.echo(val)
+
+
+@cli.command()
+@click.argument("key")
+@click.argument("value")
+@click.option("--app", required=True)
+@click.option("--scope", type=click.Choice(["user", "project"]), default="user")
+def set(app: str, key: str, value: str, scope: str) -> None:
+    """Set KEY to VALUE."""
+
+    sigil = Sigil(app)
+    sigil.set_pref(key, value, scope=scope)
+
+
+@cli.group()
+def secret() -> None:
+    """Manage secret preferences."""
+
+
+@secret.command("get")
+@click.argument("key")
+@click.option("--app", required=True)
+@click.option("--reveal", is_flag=True, help="Print the secret value")
+def secret_get(app: str, key: str, reveal: bool) -> None:
+    sigil = Sigil(app)
+    val = sigil.get_pref(key)
+    if val is None:
+        raise click.exceptions.Exit(1)
+    click.echo(val if reveal else "*" * 8)
+
+
+@secret.command("set")
+@click.argument("key")
+@click.argument("value")
+@click.option("--app", required=True)
+def secret_set(app: str, key: str, value: str) -> None:
+    sigil = Sigil(app)
+    try:
+        sigil.set_pref(key, value)
+    except Exception:
+        raise click.exceptions.Exit(1) from None
+
+
+@secret.command("unlock")
+@click.option("--app", required=True)
+def secret_unlock(app: str) -> None:
+    sigil = Sigil(app)
+    sigil._secrets.unlock()
+
+
+@cli.command()
+@click.option("--app", required=True)
+@click.option("--prefix", default="SIGIL_")
+@click.option("--json", "as_json", is_flag=True)
+def export(app: str, prefix: str, as_json: bool) -> None:
+    """Export preferences as environment variables."""
+
+    sigil = Sigil(app)
+    mapping = sigil.export_env(prefix=prefix)
+    if as_json:
+        click.echo(json.dumps(mapping))
+    else:
+        for k, v in mapping.items():
+            click.echo(f"{k}={v}")
+
+
+@cli.command()
+@click.option("--app")
+@click.option("--include-sigil", is_flag=True)
+@click.option("--no-remember", is_flag=True)
+def gui(app: str | None, include_sigil: bool, no_remember: bool) -> None:
+    """Launch the preferences GUI."""
+
+    launch_gui(
+        package=app,
+        include_sigil=include_sigil,
+        remember_state=not no_remember,
+    )
+
+
+@cli.command()
+def setup() -> None:
+    """Launch the defaults registration GUI."""
+
+    from .gui.author import main as author_main
+
+    author_main()
+
+
+# ---------------------------------------------------------------------------
+# Author commands
+# ---------------------------------------------------------------------------
+
+
+@cli.group()
+def author() -> None:
+    """Package author helpers."""
+
+
+@author.command()
+@click.option("--provider", required=True)
+@click.option("--defaults", required=True, type=click.Path(path_type=Path))
+@click.option("--add-package-data", is_flag=True)
+@click.option("--pyproject", type=click.Path(path_type=Path))
+@click.option("--no-dev-link", is_flag=True)
+@click.option("--yes", is_flag=True, help="Unused")
+def register(
+    provider: str,
+    defaults: Path,
+    add_package_data: bool,
+    pyproject: Path | None,
+    no_dev_link: bool,
+    yes: bool,
+) -> None:
+    provider = pep503_name(provider)
+    ini_path = Path(defaults)
+    try:
+        validate_defaults_file(ini_path, provider)
+    except DefaultsValidationError as exc:
+        click.echo(str(exc), err=True)
+        raise click.exceptions.Exit(1) from None
+    if not no_dev_link:
+        try:
+            dev_link(provider, ini_path)
+        except DevLinkError as exc:
+            click.echo(str(exc), err=True)
+            raise click.exceptions.Exit(1) from None
+    if add_package_data:
+        if pyproject is not None:
+            pyproject_path = pyproject
+        else:
+            pyproject_path = _find_pyproject(ini_path)
+        if pyproject_path is not None:
+            patch_pyproject_package_data(
+                pyproject_path, import_package_from(ini_path)
+            )
+
+
+@author.command("link-defaults")
+@click.argument("provider_id")
+@click.argument("path", type=click.Path(path_type=Path))
+def link_defaults(provider_id: str, path: Path) -> None:
+    provider = pep503_name(provider_id)
+    try:
+        dev_link(provider, path)
+    except (DefaultsValidationError, DevLinkError):
+        raise click.exceptions.Exit(1) from None
+
+
+@author.command("unlink-defaults")
+@click.argument("provider_id")
+def unlink_defaults(provider_id: str) -> None:
+    provider = pep503_name(provider_id)
+    ok = dev_unlink(provider)
+    if not ok:
+        raise click.exceptions.Exit(1)
+
+
+@author.command()
+@click.argument("provider_id")
+@click.argument("path", type=click.Path(path_type=Path))
+def validate(provider_id: str, path: Path) -> None:
+    provider = pep503_name(provider_id)
+    try:
+        validate_defaults_file(path, provider)
+    except DefaultsValidationError as exc:
+        click.echo(str(exc), err=True)
+        raise click.exceptions.Exit(1) from None
+
+
+@author.command("list")
+@click.option("--existing-only", is_flag=True)
+def list_links(existing_only: bool) -> None:
+    entries = dev_list(must_exist_on_disk=existing_only)
+    if not entries:
+        click.echo("No dev links found")
+        return
+    for pid, path in sorted(entries.items()):
+        status = "(ok)" if path.exists() else "(missing)"
+        click.echo(f"{pid}: {path} {status}")
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = sys.argv[1:] if argv is None else argv
     prog = os.path.basename(sys.argv[0]) or "sigil"
     if prog == "__main__.py":
         prog = "pysigil"
-    parser = build_parser(prog)
-    args = parser.parse_args(argv)
-    if args.cmd not in {"gui", "author"}:
-        sigil = Sigil(args.app)
-    if args.cmd == "get":
-        val = sigil.get_pref(args.key)
-        if val is None:
-            return 1
-        print(val)
-        return 0
-    elif args.cmd == "set":
-        sigil.set_pref(args.key, args.value, scope=args.scope)
-        return 0
-    elif args.cmd == "export":
-        mapping = sigil.export_env(prefix=args.prefix)
-        if args.json:
-            import json
-
-            print(json.dumps(mapping))
-        else:
-            for k, v in mapping.items():
-                print(f"{k}={v}")
-        return 0
-    elif args.cmd == "secret":
-        if args.scmd == "get":
-            val = sigil.get_pref(args.key)
-            if val is None:
-                return 1
-            if args.reveal:
-                print(val)
-            else:
-                print("*" * 8)
-            return 0
-        elif args.scmd == "set":
-            try:
-                sigil.set_pref(args.key, args.value)
-            except Exception:
-                return 1
-            return 0
-        elif args.scmd == "unlock":
-            sigil._secrets.unlock()
-            return 0
-    elif args.cmd == "gui":
-        launch_gui(
-            package=args.app,
-            include_sigil=args.include_sigil,
-            remember_state=not args.no_remember,
-        )
-        return 0
-    elif args.cmd == "author":
-        if args.acmd == "register":
-            provider = pep503_name(args.provider)
-            ini_path = Path(args.defaults)
-            try:
-                validate_defaults_file(ini_path, provider)
-            except DefaultsValidationError as exc:
-                print(str(exc), file=sys.stderr)
-                return 1
-            if not args.no_dev_link:
-                try:
-                    dev_link(provider, ini_path)
-                except DevLinkError as exc:
-                    print(str(exc), file=sys.stderr)
-                    return 1
-            if args.add_package_data:
-                if args.pyproject:
-                    pyproject = Path(args.pyproject)
-                else:
-                    pyproject = _find_pyproject(ini_path)
-                if pyproject is not None:
-                    patch_pyproject_package_data(
-                        pyproject, import_package_from(ini_path)
-                    )
-            return 0
-        elif args.acmd == "link-defaults":
-            provider = pep503_name(args.provider_id)
-            try:
-                dev_link(provider, Path(args.path))
-            except (DefaultsValidationError, DevLinkError):
-                return 1
-            return 0
-        elif args.acmd == "unlink-defaults":
-            provider = pep503_name(args.provider_id)
-            ok = dev_unlink(provider)
-            return 0 if ok else 1
-        elif args.acmd == "validate":
-            provider = pep503_name(args.provider_id)
-            try:
-                validate_defaults_file(Path(args.path), provider)
-            except DefaultsValidationError as exc:
-                print(str(exc), file=sys.stderr)
-                return 1
-            return 0
-        elif args.acmd == "list":
-            entries = dev_list(must_exist_on_disk=args.existing_only)
-            if not entries:
-                print("No dev links found")
-                return 0
-            for pid, path in sorted(entries.items()):
-                status = "(ok)" if path.exists() else "(missing)"
-                print(f"{pid}: {path} {status}")
-            return 0
-    return 1
+    try:
+        cli.main(args=argv, prog_name=prog, standalone_mode=False)
+    except SystemExit as exc:  # pragma: no cover - click always raises
+        return exc.code
+    return 0
 
 
 if __name__ == "__main__":
     sys.exit(main())
+


### PR DESCRIPTION
## Summary
- rewrite CLI using `click`
- add `setup` command to launch defaults registration GUI
- document new commands and add `click` dependency

## Testing
- `ruff check src/pysigil/cli.py`
- `pytest`
- (attempted) `pre-commit run --files pyproject.toml src/pysigil.egg-info/requires.txt src/pysigil.egg-info/entry_points.txt src/pysigil/cli.py README.md AUTHORS_GUIDE.md docs/gui.md` *(missing: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689e6d7c17b08328a6a216dbf7af2927