### PR TITLE
feat(author): autodetect package dir

### DIFF
--- a/AUTHORS_GUIDE.md
+++ b/AUTHORS_GUIDE.md
@@ -19,6 +19,25 @@ We use your **PEP 503 normalized** distribution name as the provider id (lowerca
 * `My_Package.Name` → `my-package-name`
 * `awesome.pkg` → `awesome-pkg`
 
+## Automatic detection
+
+Sigil can auto-detect your package from the current directory using
+`pyprojroot` and your `pyproject.toml`.
+
+```bash
+# From your repo root
+sigil author register --auto
+
+# Explicit package folder
+sigil author register --package-dir ./src/mypkg
+
+# Legacy explicit defaults path
+sigil author register --provider my-pkg --defaults ./src/mypkg/.sigil/settings.ini
+```
+
+The GUI pre-fills both fields when it can detect the package unambiguously and
+creates `.sigil/settings.ini` if it's missing.
+
 ## Option A — CLI (Click)
 
 Register a dev link:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,12 @@ description = "Preferences & secrets manager with layered scopes and tuple-key i
 readme = "README.md"
 requires-python = ">=3.10"
 version = "0.2.0"
-dependencies = ["appdirs", "tomlkit", "click"]
+dependencies = [
+  "appdirs",
+  "tomlkit",
+  "click>=8.1",
+  "pyprojroot>=0.3.0",
+]
 authors = [{ name = "Tim Marquart" }]
 
 [project.optional-dependencies]

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pysigil.resolver import (
+    default_provider_id,
+    ensure_defaults_file,
+    find_package_dir,
+    find_project_root,
+    read_dist_name_from_pyproject,
+)
+
+
+def write_pyproject(root: Path, name: str | None = None) -> None:
+    content = "[project]\n"
+    if name is not None:
+        content += f"name = \"{name}\"\n"
+    (root / "pyproject.toml").write_text(content, encoding="utf-8")
+
+
+def test_find_project_root_pyproject(tmp_path: Path) -> None:
+    write_pyproject(tmp_path)
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    assert find_project_root(sub) == tmp_path
+
+
+def test_provider_from_pyproject(tmp_path: Path) -> None:
+    write_pyproject(tmp_path, name="My_Package.Name")
+    name = read_dist_name_from_pyproject(tmp_path)
+    assert name == "My_Package.Name"
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").touch()
+    assert (
+        default_provider_id(pkg, name) == "my-package-name"
+    )
+
+
+def test_find_package_src_layout(tmp_path: Path) -> None:
+    write_pyproject(tmp_path, name="my-pkg")
+    pkg = tmp_path / "src" / "my_pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").touch()
+    found = find_package_dir(tmp_path, "my-pkg")
+    assert found == pkg
+
+
+def test_find_package_flat_layout(tmp_path: Path) -> None:
+    write_pyproject(tmp_path, name="my-pkg")
+    pkg = tmp_path / "my_pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").touch()
+    found = find_package_dir(tmp_path, "my-pkg")
+    assert found == pkg
+
+
+def test_single_package_under_src(tmp_path: Path) -> None:
+    write_pyproject(tmp_path)
+    pkg = tmp_path / "src" / "only_pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").touch()
+    found = find_package_dir(tmp_path, None)
+    assert found == pkg
+
+
+def test_ambiguous_packages(tmp_path: Path) -> None:
+    write_pyproject(tmp_path)
+    for name in ["a", "b"]:
+        pkg = tmp_path / "src" / name
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").touch()
+    assert find_package_dir(tmp_path, None) is None
+
+
+def test_ensure_defaults_file(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").touch()
+    ini = ensure_defaults_file(pkg, "prov")
+    text = ini.read_text(encoding="utf-8")
+    assert "[provider:prov]" in text


### PR DESCRIPTION
## Summary
- merge project/package detection helpers into resolver for reuse across CLI and GUI
- fold author `register` into main CLI and drop the extra shim modules
- GUI now pulls authoring helpers directly and handles missing project roots gracefully

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fa8203cb483288039d93bfe210093