### PR TITLE
Use setuptools for package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ exclude = ["appdirs"]
 [tool.setuptools.package-dir]
 "" = "src"
 
+[tool.setuptools.package-data]
+"*" = [".sigil/settings.ini"]
+
 [project]
 name = "pysigil"
 description = "Preferences & secrets manager with layered scopes and tuple-key internals"

--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -10,11 +10,9 @@ import click
 from .authoring import (
     DevLinkError,
     DefaultsValidationError,
-    import_package_from,
     link as dev_link,
     list_links as dev_list,
     normalize_provider_id,
-    patch_pyproject_package_data,
     unlink as dev_unlink,
     validate_defaults_file,
 )


### PR DESCRIPTION
## Summary
- replace custom package scanning with setuptools' `PackageFinder`
- infer defaults package via setuptools rather than path heuristics
- declare `.sigil/settings.ini` as package data and drop runtime pyproject patching

## Testing
- `pytest`
- `pre-commit run --files pyproject.toml src/pysigil/resolver.py src/pysigil/authoring.py src/pysigil/cli.py` *(failed: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689fb2d865308328be9f5f117450d837