### PR TITLE
Normalize provider defaults and GUI provider ids

### DIFF
--- a/src/pysigil/authoring.py
+++ b/src/pysigil/authoring.py
@@ -113,9 +113,9 @@ _KEY_RE = re.compile(r"^[a-z0-9]+(\.[a-z0-9_]+)*$")
 def validate_defaults_file(path: Path, provider_id: str) -> None:
     """Validate ``path`` for ``provider_id``.
 
-    The file must contain a ``[provider:<provider_id>]`` section and all keys in
-    that section must be dotted names using lowercase letters, digits and
-    underscores after the first segment.
+    The file must contain a ``[<provider_id>]`` section and all keys in that
+    section must be dotted names using lowercase letters, digits and underscores
+    after the first segment.
     """
 
     path = Path(path).expanduser().resolve()
@@ -128,7 +128,7 @@ def validate_defaults_file(path: Path, provider_id: str) -> None:
     except Exception as exc:  # pragma: no cover - defensive
         raise DefaultsValidationError(str(exc)) from exc
 
-    section = f"provider:{provider_id}"
+    section = provider_id
     if section not in parser:
         raise DefaultsValidationError("missing provider section")
     for key in parser[section]:

--- a/src/pysigil/gui/__init__.py
+++ b/src/pysigil/gui/__init__.py
@@ -64,20 +64,20 @@ def open_package(package: str, include_sigil: bool) -> None:
     try:
         from . import hub
 
-        get_pref, *_ = hub.get_preferences(package)
+        get_pref, _, sig = hub.get_preferences(package)
         # Force instantiation of the package-specific Sigil by performing a
         # harmless lookup.  ``get_preferences`` creates the instance lazily, so
         # without this call ``hub._instances`` would remain empty and the GUI
         # would show no values for newly selected packages.
         get_pref("__sigil_gui_init__", default=None)
-        _sigil_instance = hub._instances.get(package)  # type: ignore[attr-defined]
-        logger.debug("loaded instance for %s via hub", package)
+        _sigil_instance = sig
+        logger.debug("loaded instance for %s via hub", sig.app_name)
     except Exception as exc:
         logger.debug("hub resolution failed for %s: %s", package, exc)
         from ..core import Sigil
 
         _sigil_instance = Sigil(package)
-    _current_package = package
+    _current_package = _sigil_instance.app_name
     # ``include_sigil`` is currently unused but kept for API compatibility.
 
 
@@ -293,6 +293,7 @@ def launch_gui(
             or "pysigil"
         )
         open_package(pkg, include_sigil)
+        pkg = _current_package or pkg
         if pkg not in packages:
             packages = [pkg, *packages]
 

--- a/src/pysigil/gui/hub.py
+++ b/src/pysigil/gui/hub.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from ..core import Sigil
+from ..discovery import pep503_name
 
 _instances: dict[str, Sigil] = {}
 
 
 def get_preferences(package: str) -> tuple[Callable[..., object], Callable[..., object], Sigil]:
-    sig = _instances.get(package)
+    provider = pep503_name(package)
+    sig = _instances.get(provider)
     if sig is None:
-        sig = Sigil(package)
-        _instances[package] = sig
+        sig = Sigil(provider)
+        _instances[provider] = sig
     return sig.get_pref, sig.set_pref, sig
 
 

--- a/src/pysigil/resolver.py
+++ b/src/pysigil/resolver.py
@@ -235,7 +235,7 @@ def ensure_defaults_file(package_dir: Path, provider_id: str) -> Path:
     ini = sigil_dir / "settings.ini"
     if not ini.exists():
         template = (
-            f"[provider:{provider_id}]\n"
+            f"[{provider_id}]\n"
             "# Add your package defaults here.\n"
             "# key = value\n"
         )

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -79,4 +79,4 @@ def test_ensure_defaults_file(tmp_path: Path) -> None:
     (pkg / "__init__.py").touch()
     ini = ensure_defaults_file(pkg, "prov")
     text = ini.read_text(encoding="utf-8")
-    assert "[provider:prov]" in text
+    assert "[prov]" in text


### PR DESCRIPTION
## Summary
- drop `provider:` prefix from generated settings files
- validate defaults against `[provider_id]` sections
- normalize package names in GUI hub and launcher

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fb774ac8c8328b8f04725fc1b1eb2