### PR TITLE
Normalize app names for config loading

### DIFF
--- a/src/pysigil/merge_policy.py
+++ b/src/pysigil/merge_policy.py
@@ -19,7 +19,8 @@ def parse_key(raw: str | KeyPath) -> KeyPath:
 
 
 def read_env(app_name: str) -> MutableMapping[KeyPath, str]:
-    prefix = f"SIGIL_{app_name.upper()}_"
+    sanitized = app_name.upper().replace("-", "_")
+    prefix = f"SIGIL_{sanitized}_"
     result: MutableMapping[KeyPath, str] = {}
     for key, value in os.environ.items():
         if key.startswith(prefix):

--- a/src/pysigil/secrets/__init__.py
+++ b/src/pysigil/secrets/__init__.py
@@ -106,7 +106,7 @@ class EnvSecretProvider:
     """Read-only provider using environment variables."""
 
     def __init__(self, app_name: str) -> None:
-        self._prefix = f"SIGIL_SECRET_{app_name.upper()}_"
+        self._prefix = f"SIGIL_SECRET_{app_name.upper().replace('-', '_')}_"
 
     def available(self) -> bool:  # pragma: no cover - trivial
         return True

--- a/tests/test_name_normalization.py
+++ b/tests/test_name_normalization.py
@@ -1,0 +1,18 @@
+from pysigil import Sigil
+
+
+def test_defaults_section_normalized(tmp_path):
+    defaults_dir = tmp_path / ".sigil"
+    defaults_dir.mkdir()
+    defaults_file = defaults_dir / "settings.ini"
+    defaults_file.write_text("[sigil_dummy]\nfoo=bar\n", encoding="utf-8")
+
+    sig = Sigil("sigil-dummy", default_path=defaults_file, user_scope=tmp_path / "user.ini")
+    assert sig.get_pref("foo") == "bar"
+    assert ("foo",) in sig.list_keys("default")
+
+
+def test_env_prefix_normalized(tmp_path, monkeypatch):
+    monkeypatch.setenv("SIGIL_SIGIL_DUMMY_FOO", "42")
+    sig = Sigil("sigil-dummy", user_scope=tmp_path / "user.ini")
+    assert sig.get_pref("foo") == 42


### PR DESCRIPTION
## Summary
- Normalize application names to PEP 503 form and use across Sigil
- Normalise keys from config files to accept underscores or hyphens interchangeably
- Handle hyphenated names in env/secret providers
- Add regression tests for name normalisation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fd7c243748328a4e8ab895eee0e00