### PR TITLE
Add Sigil config loader, CLI tools, and GUI

### DIFF
--- a/src/pysigil/authoring.py
+++ b/src/pysigil/authoring.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from appdirs import user_config_dir
+
 try:  # pragma: no cover - fallback when setuptools is missing
     from setuptools import PackageFinder  # type: ignore
 except Exception:  # pragma: no cover - defensive

--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import configparser
 import json
 import os
 import sys
@@ -15,6 +16,13 @@ from .authoring import (
     normalize_provider_id,
     unlink as dev_unlink,
     validate_defaults_file,
+)
+from .config import (
+    ensure_gitignore as cfg_ensure_gitignore,
+    host_file as cfg_host_file,
+    init_config as cfg_init_config,
+    load as cfg_load,
+    open_scope as cfg_open_scope,
 )
 from .core import Sigil
 from .discovery import pep503_name
@@ -32,6 +40,81 @@ from .resolver import (
 @click.group()
 def cli() -> None:
     """Sigil command line interface."""
+
+
+# ---------------------------------------------------------------------------
+# Config commands
+# ---------------------------------------------------------------------------
+
+
+@cli.group()
+def config() -> None:
+    """Manage Sigil configuration files."""
+
+
+@config.command("init")
+@click.option("--provider", required=True)
+@click.option("--scope", type=click.Choice(["user", "project"]), default="user")
+@click.option("--auto", is_flag=True, help="Auto-detect project root")
+def config_init(provider: str, scope: str, auto: bool) -> None:
+    path = cfg_init_config(provider, scope, auto=auto)
+    click.echo(str(path))
+
+
+@config.command("open")
+@click.option("--provider", required=True)
+@click.option("--scope", type=click.Choice(["user", "project"]), default="user")
+@click.option("--auto", is_flag=True, help="Auto-detect project root")
+def config_open(provider: str, scope: str, auto: bool) -> None:  # pragma: no cover - best effort
+    path = cfg_open_scope(scope, auto=auto)
+    try:
+        click.launch(str(path))
+    except Exception:
+        pass
+    click.echo(str(path))
+
+
+@config.command("host")
+@click.option("--provider", required=True)
+@click.option("--scope", type=click.Choice(["user", "project"]), default="user")
+@click.option("--auto", is_flag=True, help="Auto-detect project root")
+def config_host(provider: str, scope: str, auto: bool) -> None:  # pragma: no cover - best effort
+    try:
+        path = cfg_host_file(provider, scope, auto=auto)
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from None
+    try:
+        click.launch(str(path))
+    except Exception:
+        pass
+    click.echo(str(path))
+
+
+@config.command("show")
+@click.option("--provider", required=True)
+@click.option("--as", "format", type=click.Choice(["ini", "json"]), default="ini")
+@click.option("--auto", is_flag=True, help="Auto-detect project root")
+def config_show(provider: str, format: str, auto: bool) -> None:
+    data = cfg_load(provider, auto=auto)
+    if format == "json":
+        click.echo(json.dumps(data))
+        return
+    parser = configparser.ConfigParser()
+    parser[normalize_provider_id(provider)] = {k: str(v) for k, v in data.items()}
+    from io import StringIO
+
+    buf = StringIO()
+    parser.write(buf)
+    click.echo(buf.getvalue().strip())
+
+
+@config.command("gitignore")
+@click.option("--init", is_flag=True, help="Add ignore rule")
+@click.option("--auto", is_flag=True, help="Auto-detect project root")
+def config_gitignore(init: bool, auto: bool) -> None:
+    if init:
+        path = cfg_ensure_gitignore(auto=auto)
+        click.echo(str(path))
 
 
 # ---------------------------------------------------------------------------

--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -9,8 +9,8 @@ from pathlib import Path
 import click
 
 from .authoring import (
-    DevLinkError,
     DefaultsValidationError,
+    DevLinkError,
     link as dev_link,
     list_links as dev_list,
     normalize_provider_id,

--- a/src/pysigil/config.py
+++ b/src/pysigil/config.py
@@ -10,7 +10,6 @@ from appdirs import user_config_dir
 from .authoring import normalize_provider_id
 from .resolver import ProjectRootNotFoundError, find_project_root
 
-
 # ---------------------------------------------------------------------------
 # Host and provider helpers
 # ---------------------------------------------------------------------------

--- a/src/pysigil/config.py
+++ b/src/pysigil/config.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import configparser
+import socket
+from pathlib import Path
+from typing import Any
+
+from appdirs import user_config_dir
+
+from .authoring import normalize_provider_id
+from .resolver import ProjectRootNotFoundError, find_project_root
+
+
+# ---------------------------------------------------------------------------
+# Host and provider helpers
+# ---------------------------------------------------------------------------
+
+def host_id() -> str:
+    """Return the normalised hostname."""
+    raw = socket.gethostname()
+    return normalize_provider_id(raw).strip("-")
+
+
+# ---------------------------------------------------------------------------
+# File discovery
+# ---------------------------------------------------------------------------
+
+def user_files(host: str) -> list[Path]:
+    base = Path(user_config_dir("sigil"))
+    files = [base / "settings.ini", base / f"settings-local-{host}.ini"]
+    return [f for f in files if f.exists()]
+
+
+def _project_dir(auto: bool) -> Path | None:
+    if auto:
+        try:
+            return find_project_root()
+        except ProjectRootNotFoundError:
+            return None
+    return Path.cwd()
+
+
+def project_files(host: str, *, auto: bool = True) -> list[Path]:
+    root = _project_dir(auto)
+    if root is None:
+        return []
+    base = root / ".sigil"
+    files = [base / "settings.ini", base / f"settings-local-{host}.ini"]
+    return [f for f in files if f.exists()]
+
+
+# ---------------------------------------------------------------------------
+# Reading helpers
+# ---------------------------------------------------------------------------
+
+def merge_ini_section(acc: dict[str, Any], ini_path: Path, *, section: str) -> dict[str, Any]:
+    parser = configparser.ConfigParser()
+    try:
+        parser.read(ini_path)
+    except Exception:
+        return acc
+    if parser.has_section(section):
+        for k, v in parser.items(section):
+            acc[k] = v
+    return acc
+
+
+def load(provider_id: str, *, auto: bool = True) -> dict[str, Any]:
+    pid = normalize_provider_id(provider_id)
+    h = host_id()
+    acc: dict[str, Any] = {}
+    for f in user_files(h):
+        acc = merge_ini_section(acc, f, section=pid)
+    for f in project_files(h, auto=auto):
+        acc = merge_ini_section(acc, f, section=pid)
+    return acc
+
+
+# ---------------------------------------------------------------------------
+# Writing helpers used by CLI and GUI
+# ---------------------------------------------------------------------------
+
+def _scope_dir(scope: str, *, auto: bool) -> Path:
+    if scope == "user":
+        base = Path(user_config_dir("sigil"))
+    else:
+        root = _project_dir(auto)
+        if root is None:
+            raise ProjectRootNotFoundError("No project root found")
+        base = root / ".sigil"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _seed_section(path: Path, section: str, comment: str) -> None:
+    if path.exists():
+        parser = configparser.ConfigParser()
+        try:
+            parser.read(path)
+        except Exception:
+            parser = None
+        if parser and parser.has_section(section):
+            return
+        with path.open("a") as fh:
+            fh.write(f"\n[{section}]\n{comment}")
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"[{section}]\n{comment}")
+
+
+def init_config(provider_id: str, scope: str, *, auto: bool = False) -> Path:
+    pid = normalize_provider_id(provider_id)
+    h = host_id()
+    base = _scope_dir(scope, auto=auto)
+    if pid == "user-custom":
+        path = base / f"settings-local-{h}.ini"
+        comment = "# per-machine user-custom settings\n"
+    else:
+        path = base / "settings.ini"
+        comment = "# add keys here\n"
+    _seed_section(path, pid, comment)
+    return path
+
+
+def open_scope(scope: str, *, auto: bool = False) -> Path:
+    return _scope_dir(scope, auto=auto)
+
+
+def host_file(provider_id: str, scope: str, *, auto: bool = False) -> Path:
+    pid = normalize_provider_id(provider_id)
+    if pid != "user-custom":
+        raise ValueError("host command is only valid for provider 'user-custom'")
+    return init_config(pid, scope, auto=auto)
+
+
+def ensure_gitignore(*, auto: bool = False) -> Path:
+    root = _project_dir(auto)
+    if root is None:
+        raise ProjectRootNotFoundError("No project root found")
+    gi = root / ".gitignore"
+    rule = ".sigil/settings-local*"
+    lines: list[str] = []
+    if gi.exists():
+        lines = gi.read_text().splitlines()
+    if rule not in lines:
+        lines.append(rule)
+        gi.write_text("\n".join(lines) + "\n")
+    return gi

--- a/src/pysigil/core.py
+++ b/src/pysigil/core.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from threading import RLock
 from typing import Any
 
+from .discovery import pep503_name
 from .errors import (
     ReadOnlyScopeError,
     SigilError,  # noqa: F401 - re-exported for compatibility
@@ -16,7 +17,6 @@ from .errors import (
 )
 from .gui import events
 from .merge_policy import CORE_DEFAULTS, KeyPath, parse_key, read_env
-from .discovery import pep503_name
 from .resolver import (
     ProjectRootNotFoundError,
     project_settings_file,

--- a/src/pysigil/gui/__init__.py
+++ b/src/pysigil/gui/__init__.py
@@ -16,8 +16,8 @@ except Exception:  # pragma: no cover - fallback for headless tests
 
 from ..merge_policy import KeyPath
 from . import events, gui_state
-from .widgets import widget_for
 from .config_gui import launch as launch_config_gui
+from .widgets import widget_for
 
 if TYPE_CHECKING:
     from ..core import Sigil
@@ -404,6 +404,7 @@ __all__ = [
     "current_keys",
     "effective_scope_for",
     "launch_gui",
+    "launch_config_gui",
     "_open_value_dialog",
     "_populate_tree",
     "_on_add",

--- a/src/pysigil/gui/__init__.py
+++ b/src/pysigil/gui/__init__.py
@@ -17,6 +17,7 @@ except Exception:  # pragma: no cover - fallback for headless tests
 from ..merge_policy import KeyPath
 from . import events, gui_state
 from .widgets import widget_for
+from .config_gui import launch as launch_config_gui
 
 if TYPE_CHECKING:
     from ..core import Sigil

--- a/src/pysigil/gui/author.py
+++ b/src/pysigil/gui/author.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import os
 import sys
+import tkinter as tk
 import webbrowser
 from pathlib import Path
-import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
 from ..authoring import DevLinkError, _dev_dir, link, normalize_provider_id

--- a/src/pysigil/gui/config_gui.py
+++ b/src/pysigil/gui/config_gui.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+
+from ..config import host_id, init_config, open_scope
+
+
+def launch() -> None:  # pragma: no cover - GUI interactions
+    root = tk.Tk()
+    root.title("Sigil Config")
+    ttk.Label(root, text=f"Host: {host_id()}").pack(padx=10, pady=10)
+
+    def do_init() -> None:
+        init_config("user-custom", "user")
+
+    ttk.Button(root, text="Initialize User Custom", command=do_init).pack(pady=5)
+
+    def do_open() -> None:
+        path = open_scope("user")
+        try:
+            import click
+
+            click.launch(str(path))
+        except Exception:
+            pass
+
+    ttk.Button(root, text="Open user config folder", command=do_open).pack(pady=5)
+
+    root.mainloop()

--- a/src/pysigil/resolver.py
+++ b/src/pysigil/resolver.py
@@ -1,12 +1,13 @@
 """Utilities for resolving configuration file locations and project roots."""
 
+import re
 from importlib import resources
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
-import re
 
 from appdirs import user_config_dir
 from pyprojroot import here
+
 try:  # pragma: no cover - Python <3.11
     import tomllib  # type: ignore
 except Exception:  # pragma: no cover - fallback

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from pysigil import config as cfg
+from pysigil.cli import cli
+
+
+def _fake_user_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "user"
+    d.mkdir()
+    return d
+
+
+def _fake_project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "proj"
+    (root / ".sigil").mkdir(parents=True)
+    (root / "pyproject.toml").write_text("[project]\nname='demo'\n")
+    return root
+
+
+def _patch_env(monkeypatch, tmp_path: Path, host: str = "host") -> tuple[Path, Path]:
+    user_dir = _fake_user_dir(tmp_path)
+    project_root = _fake_project_root(tmp_path)
+    monkeypatch.setattr(cfg, "user_config_dir", lambda app: str(user_dir))
+    monkeypatch.setattr(cfg, "find_project_root", lambda: project_root)
+    monkeypatch.setattr(cfg.socket, "gethostname", lambda: host)
+    return user_dir, project_root
+
+
+def test_precedence(monkeypatch, tmp_path: Path) -> None:
+    user_dir, project_root = _patch_env(monkeypatch, tmp_path)
+    (user_dir / "settings.ini").write_text("[pkg]\na=1\n")
+    (user_dir / "settings-local-host.ini").write_text("[pkg]\na=2\n")
+    proj_dir = project_root / ".sigil"
+    (proj_dir / "settings.ini").write_text("[pkg]\na=3\n")
+    (proj_dir / "settings-local-host.ini").write_text("[pkg]\na=4\n")
+    data = cfg.load("pkg")
+    assert data == {"a": "4"}
+
+
+def test_write_policy(monkeypatch, tmp_path: Path) -> None:
+    user_dir, _ = _patch_env(monkeypatch, tmp_path)
+    runner = CliRunner()
+    res = runner.invoke(cli, ["config", "init", "--provider", "user-custom", "--scope", "user"])
+    assert res.exit_code == 0
+    assert (user_dir / "settings-local-host.ini").exists()
+    assert not (user_dir / "settings.ini").exists()
+    res = runner.invoke(cli, ["config", "init", "--provider", "mypkg", "--scope", "user"])
+    assert res.exit_code == 0
+    assert (user_dir / "settings.ini").exists()
+    res = runner.invoke(cli, ["config", "host", "--provider", "mypkg"])
+    assert res.exit_code != 0
+
+
+def test_host_filtering(monkeypatch, tmp_path: Path) -> None:
+    user_dir, project_root = _patch_env(monkeypatch, tmp_path)
+    (user_dir / "settings-local-host.ini").write_text("[pkg]\nx=1\n")
+    (user_dir / "settings-local-other.ini").write_text("[pkg]\nx=2\n")
+    proj_dir = project_root / ".sigil"
+    (proj_dir / "settings-local-host.ini").write_text("[pkg]\ny=3\n")
+    (proj_dir / "settings-local-other.ini").write_text("[pkg]\ny=4\n")
+    data = cfg.load("pkg")
+    assert data == {"x": "1", "y": "3"}
+
+
+def test_gitignore_idempotent(monkeypatch, tmp_path: Path) -> None:
+    _, project_root = _patch_env(monkeypatch, tmp_path)
+    runner = CliRunner()
+    runner.invoke(cli, ["config", "gitignore", "--init", "--auto"])
+    runner.invoke(cli, ["config", "gitignore", "--init", "--auto"])
+    content = (project_root / ".gitignore").read_text().splitlines()
+    assert content == [".sigil/settings-local*"]
+
+
+def test_cli_roundtrip(monkeypatch, tmp_path: Path) -> None:
+    user_dir, project_root = _patch_env(monkeypatch, tmp_path)
+    runner = CliRunner()
+    runner.invoke(cli, ["config", "init", "--provider", "pkg", "--scope", "user"])
+    runner.invoke(
+        cli,
+        ["config", "init", "--provider", "pkg", "--scope", "project", "--auto"],
+    )
+    (user_dir / "settings.ini").write_text("[pkg]\nkey=user\n")
+    proj_dir = project_root / ".sigil"
+    (proj_dir / "settings.ini").write_text("[pkg]\nkey=project\n")
+    res = runner.invoke(
+        cli,
+        ["config", "show", "--provider", "pkg", "--as", "json", "--auto"],
+    )
+    assert res.exit_code == 0
+    assert json.loads(res.output) == {"key": "project"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from pysigil import config as cfg

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,5 +1,6 @@
-import pysigil.discovery as discovery
 import pytest
+
+import pysigil.discovery as discovery
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Implement host-aware Sigil config loader with user/project precedence
- Provide `sigil config` CLI with init/open/host/show/gitignore subcommands
- Add minimal GUI for initializing user-custom settings
- Cover spec with comprehensive tests

## Testing
- `pytest -q`
- `pre-commit run --files src/pysigil/config.py src/pysigil/cli.py src/pysigil/gui/config_gui.py src/pysigil/gui/__init__.py tests/test_config.py` *(fails: command not found, pre-commit unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ca1ba5508328a3e43a41aa5e3dc5