### PR TITLE
Add CLI command to launch config GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ preferences. After installation launch it with:
 sigil gui
 ```
 
+To initialise or inspect the user configuration directory from a small
+helper interface, run:
+
+```bash
+sigil config gui
+```
+
 Package authors can register development defaults via:
 
 ```bash

--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -117,6 +117,15 @@ def config_gitignore(init: bool, auto: bool) -> None:
         click.echo(str(path))
 
 
+@config.command("gui")
+def config_gui() -> None:  # pragma: no cover - GUI interactions
+    """Launch the config GUI."""
+
+    from .gui import launch_config_gui
+
+    launch_config_gui()
+
+
 # ---------------------------------------------------------------------------
 # Basic commands
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `sigil config gui` subcommand to launch the configuration GUI
- document how to open the configuration GUI via the CLI

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/cli.py README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d0343d8083288bca66c89905026e