### PR TITLE
Add CLI command to launch config GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ preferences. After installation launch it with:
 sigil gui
 ```
 
+To initialise or inspect the user configuration directory from a small
+helper interface, run:
+
+```bash
+sigil config gui
+```
+
+Click **Initialize User Custom** to create a per-host `user-custom` section.
+A confirmation dialog appears and the user configuration folder opens so you
+can edit the newly created file.
+
 Package authors can register development defaults via:
 
 ```bash

--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -117,6 +117,15 @@ def config_gitignore(init: bool, auto: bool) -> None:
         click.echo(str(path))
 
 
+@config.command("gui")
+def config_gui() -> None:  # pragma: no cover - GUI interactions
+    """Launch the config GUI."""
+
+    from .gui import launch_config_gui
+
+    launch_config_gui()
+
+
 # ---------------------------------------------------------------------------
 # Basic commands
 # ---------------------------------------------------------------------------

--- a/src/pysigil/gui/config_gui.py
+++ b/src/pysigil/gui/config_gui.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import tkinter as tk
-from tkinter import ttk
+from tkinter import messagebox, ttk
 
 from ..config import host_id, init_config, open_scope
 
@@ -10,11 +10,6 @@ def launch() -> None:  # pragma: no cover - GUI interactions
     root = tk.Tk()
     root.title("Sigil Config")
     ttk.Label(root, text=f"Host: {host_id()}").pack(padx=10, pady=10)
-
-    def do_init() -> None:
-        init_config("user-custom", "user")
-
-    ttk.Button(root, text="Initialize User Custom", command=do_init).pack(pady=5)
 
     def do_open() -> None:
         path = open_scope("user")
@@ -25,6 +20,15 @@ def launch() -> None:  # pragma: no cover - GUI interactions
         except Exception:
             pass
 
+    def do_init() -> None:
+        path = init_config("user-custom", "user")
+        try:
+            messagebox.showinfo("Sigil Config", f"Initialized user-custom at {path}")
+        except Exception:
+            pass
+        do_open()
+
+    ttk.Button(root, text="Initialize User Custom", command=do_init).pack(pady=5)
     ttk.Button(root, text="Open user config folder", command=do_open).pack(pady=5)
 
     root.mainloop()


### PR DESCRIPTION
## Summary
- add `sigil config gui` subcommand to launch the configuration GUI
- confirm user-custom initialization with a dialog and open the config directory
- document initialization confirmation for the config GUI

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/gui/config_gui.py README.md` *(fails: command not found; pre-commit installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d0343d8083288bca66c89905026e