### PR TITLE
Add CLI command to launch config GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sigil get ui.color --app demo
 sigil export --app demo
 ```
 
-The CLI stores data under your user config directory (e.g. `~/.config/demo`),
+The CLI stores data under your user config directory (e.g. `~/.config/sigil/demo/settings.ini`),
 so you can run these commands right from the source tree without creating a
 separate project. See `tests/manual_tests/README.md` for more examples.
 
@@ -48,6 +48,17 @@ preferences. After installation launch it with:
 ```bash
 sigil gui
 ```
+
+To initialise or inspect the user configuration directory from a small
+helper interface, run:
+
+```bash
+sigil config gui
+```
+
+Click **Initialize User Custom** to create a per-host `user-custom` section.
+A confirmation dialog appears and the folder opens (e.g.
+`~/.config/sigil/user-custom`) so you can edit the newly created file.
 
 Package authors can register development defaults via:
 

--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -66,7 +66,7 @@ def config_init(provider: str, scope: str, auto: bool) -> None:
 @click.option("--scope", type=click.Choice(["user", "project"]), default="user")
 @click.option("--auto", is_flag=True, help="Auto-detect project root")
 def config_open(provider: str, scope: str, auto: bool) -> None:  # pragma: no cover - best effort
-    path = cfg_open_scope(scope, auto=auto)
+    path = cfg_open_scope(provider, scope, auto=auto)
     try:
         click.launch(str(path))
     except Exception:
@@ -115,6 +115,15 @@ def config_gitignore(init: bool, auto: bool) -> None:
     if init:
         path = cfg_ensure_gitignore(auto=auto)
         click.echo(str(path))
+
+
+@config.command("gui")
+def config_gui() -> None:  # pragma: no cover - GUI interactions
+    """Launch the config GUI."""
+
+    from .gui import launch_config_gui
+
+    launch_config_gui()
 
 
 # ---------------------------------------------------------------------------

--- a/src/pysigil/gui/config_gui.py
+++ b/src/pysigil/gui/config_gui.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import tkinter as tk
-from tkinter import ttk
+from tkinter import messagebox, ttk
 
 from ..config import host_id, init_config, open_scope
 
@@ -11,20 +11,27 @@ def launch() -> None:  # pragma: no cover - GUI interactions
     root.title("Sigil Config")
     ttk.Label(root, text=f"Host: {host_id()}").pack(padx=10, pady=10)
 
-    def do_init() -> None:
-        init_config("user-custom", "user")
-
-    ttk.Button(root, text="Initialize User Custom", command=do_init).pack(pady=5)
-
     def do_open() -> None:
-        path = open_scope("user")
+        path = open_scope("user-custom", "user")
         try:
             import click
 
             click.launch(str(path))
         except Exception:
-            pass
+            try:
+                messagebox.showerror("Sigil Config", f"Could not open {path}")
+            except Exception:
+                pass
 
+    def do_init() -> None:
+        path = init_config("user-custom", "user")
+        try:
+            messagebox.showinfo("Sigil Config", f"Initialized user-custom at {path}")
+        except Exception:
+            pass
+        do_open()
+
+    ttk.Button(root, text="Initialize User Custom", command=do_init).pack(pady=5)
     ttk.Button(root, text="Open user config folder", command=do_open).pack(pady=5)
 
     root.mainloop()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,9 +33,11 @@ def _patch_env(monkeypatch, tmp_path: Path, host: str = "host") -> tuple[Path, P
 
 def test_precedence(monkeypatch, tmp_path: Path) -> None:
     user_dir, project_root = _patch_env(monkeypatch, tmp_path)
-    (user_dir / "settings.ini").write_text("[pkg]\na=1\n")
-    (user_dir / "settings-local-host.ini").write_text("[pkg]\na=2\n")
-    proj_dir = project_root / ".sigil"
+    (user_dir / "pkg").mkdir()
+    (user_dir / "pkg" / "settings.ini").write_text("[pkg]\na=1\n")
+    (user_dir / "pkg" / "settings-local-host.ini").write_text("[pkg]\na=2\n")
+    proj_dir = project_root / ".sigil" / "pkg"
+    proj_dir.mkdir(parents=True)
     (proj_dir / "settings.ini").write_text("[pkg]\na=3\n")
     (proj_dir / "settings-local-host.ini").write_text("[pkg]\na=4\n")
     data = cfg.load("pkg")
@@ -47,20 +49,22 @@ def test_write_policy(monkeypatch, tmp_path: Path) -> None:
     runner = CliRunner()
     res = runner.invoke(cli, ["config", "init", "--provider", "user-custom", "--scope", "user"])
     assert res.exit_code == 0
-    assert (user_dir / "settings-local-host.ini").exists()
-    assert not (user_dir / "settings.ini").exists()
+    assert (user_dir / "user-custom" / "settings-local-host.ini").exists()
+    assert not (user_dir / "user-custom" / "settings.ini").exists()
     res = runner.invoke(cli, ["config", "init", "--provider", "mypkg", "--scope", "user"])
     assert res.exit_code == 0
-    assert (user_dir / "settings.ini").exists()
+    assert (user_dir / "mypkg" / "settings.ini").exists()
     res = runner.invoke(cli, ["config", "host", "--provider", "mypkg"])
     assert res.exit_code != 0
 
 
 def test_host_filtering(monkeypatch, tmp_path: Path) -> None:
     user_dir, project_root = _patch_env(monkeypatch, tmp_path)
-    (user_dir / "settings-local-host.ini").write_text("[pkg]\nx=1\n")
-    (user_dir / "settings-local-other.ini").write_text("[pkg]\nx=2\n")
-    proj_dir = project_root / ".sigil"
+    (user_dir / "pkg").mkdir()
+    (user_dir / "pkg" / "settings-local-host.ini").write_text("[pkg]\nx=1\n")
+    (user_dir / "pkg" / "settings-local-other.ini").write_text("[pkg]\nx=2\n")
+    proj_dir = project_root / ".sigil" / "pkg"
+    proj_dir.mkdir(parents=True)
     (proj_dir / "settings-local-host.ini").write_text("[pkg]\ny=3\n")
     (proj_dir / "settings-local-other.ini").write_text("[pkg]\ny=4\n")
     data = cfg.load("pkg")
@@ -73,7 +77,7 @@ def test_gitignore_idempotent(monkeypatch, tmp_path: Path) -> None:
     runner.invoke(cli, ["config", "gitignore", "--init", "--auto"])
     runner.invoke(cli, ["config", "gitignore", "--init", "--auto"])
     content = (project_root / ".gitignore").read_text().splitlines()
-    assert content == [".sigil/settings-local*"]
+    assert content == [".sigil/*/settings-local*"]
 
 
 def test_cli_roundtrip(monkeypatch, tmp_path: Path) -> None:
@@ -84,8 +88,8 @@ def test_cli_roundtrip(monkeypatch, tmp_path: Path) -> None:
         cli,
         ["config", "init", "--provider", "pkg", "--scope", "project", "--auto"],
     )
-    (user_dir / "settings.ini").write_text("[pkg]\nkey=user\n")
-    proj_dir = project_root / ".sigil"
+    (user_dir / "pkg" / "settings.ini").write_text("[pkg]\nkey=user\n")
+    proj_dir = project_root / ".sigil" / "pkg"
     (proj_dir / "settings.ini").write_text("[pkg]\nkey=project\n")
     res = runner.invoke(
         cli,


### PR DESCRIPTION
## Summary
- store config files under provider-specific subdirectories
- fix config GUI folder button to open the right directory
- document provider folder structure in README

## Testing
- `pytest`
- `pre-commit run --files README.md src/pysigil/config.py src/pysigil/cli.py src/pysigil/gui/config_gui.py tests/test_config.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d0343d8083288bca66c89905026e