### PR TITLE
Allow writing to explicit default paths

### DIFF
--- a/src/pysigil/core.py
+++ b/src/pysigil/core.py
@@ -99,13 +99,14 @@ class Sigil:
                 self.default_path.suffix == ""
                 or self.default_path.name != self.settings_filename
             ):
-                self.default_path = self.default_path / self.settings_filename
+                self.default_path = self.default_path / ".sigil" / self.settings_filename
             self._default_source = "explicit"
+            self._defaults_writable = True
         else:
             self.default_path, self._default_source = resolve_defaults(
                 self.app_name, filename=self.settings_filename
             )
-        self._defaults_writable = self._default_source == "dev-link"
+            self._defaults_writable = self._default_source == "dev-link"
 
         self._defaults: MutableMapping[KeyPath, str] = {}
         if defaults:

--- a/tests/test_core_basic.py
+++ b/tests/test_core_basic.py
@@ -43,3 +43,14 @@ def test_dev_link_defaults_writable(tmp_path: Path, monkeypatch) -> None:
     assert s.get_pref("foo") == 8
     assert "foo = 8" in settings.read_text()
 
+
+def test_explicit_default_path_writable(tmp_path: Path) -> None:
+    default_dir = tmp_path / "defaults"
+    s = Sigil("demo", user_scope=tmp_path / "user.ini", default_path=default_dir)
+    s.set_pref("foo", "bar", scope="default")
+    assert s.get_pref("foo") == "bar"
+    settings_file = default_dir / ".sigil" / "settings.ini"
+    assert "foo = bar" in settings_file.read_text()
+    s2 = Sigil("demo", user_scope=tmp_path / "user2.ini", default_path=default_dir)
+    assert s2.get_pref("foo") == "bar"
+


### PR DESCRIPTION
## Summary
- allow writing to defaults when a `default_path` is explicitly provided
- add regression test for explicit default paths
- ensure explicit default paths store settings under a `.sigil` directory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0dbffbe4483289a7bc1f84ff12275