### PR TITLE
Refactor paths and root handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["pysigil*"]
-exclude = ["appdirs"]
 
 [tool.setuptools.package-dir]
 "" = "src"
@@ -20,7 +19,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 version = "0.3.0"
 dependencies = [
-  "appdirs",
+  "platformdirs>=4.0",
   "tomlkit",
   "click>=8.1",
   "pyprojroot>=0.3.0",

--- a/src/pysigil/authoring.py
+++ b/src/pysigil/authoring.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from appdirs import user_config_dir
+from .paths import user_config_dir
 
 try:  # pragma: no cover - fallback when setuptools is missing
     from setuptools import PackageFinder  # type: ignore

--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -28,12 +28,22 @@ from .core import Sigil
 from .discovery import pep503_name
 from .gui import launch_gui
 from .resolver import (
-    ProjectRootNotFoundError,
     default_provider_id,
     ensure_defaults_file,
     find_package_dir,
-    find_project_root,
     read_dist_name_from_pyproject,
+)
+from .root import ProjectRootNotFoundError, find_project_root
+from .paths import (
+    user_config_dir,
+    user_data_dir,
+    user_cache_dir,
+    project_root as paths_project_root,
+    project_config_dir,
+    project_data_dir,
+    project_cache_dir,
+    default_config_dir,
+    default_data_dir,
 )
 
 
@@ -45,6 +55,27 @@ def cli() -> None:
 # ---------------------------------------------------------------------------
 # Config commands
 # ---------------------------------------------------------------------------
+
+@cli.command("paths")
+@click.option("--start", type=click.Path(path_type=Path), default=None)
+@click.option("--json", "as_json", is_flag=True)
+def show_paths(start: Path | None, as_json: bool) -> None:
+    data = {
+        "user_config": user_config_dir(),
+        "user_data": user_data_dir(),
+        "user_cache": user_cache_dir(),
+        "project_root": paths_project_root(start=start),
+        "project_config": project_config_dir(start=start),
+        "project_data": project_data_dir(start=start),
+        "project_cache": project_cache_dir(start=start),
+        "default_config": default_config_dir(),
+        "default_data": default_data_dir(),
+    }
+    if as_json:
+        click.echo(json.dumps({k: str(v) for k, v in data.items()}))
+    else:
+        for k, v in data.items():
+            click.echo(f"{k}: {v}")
 
 
 @cli.group()

--- a/src/pysigil/config.py
+++ b/src/pysigil/config.py
@@ -5,10 +5,10 @@ import socket
 from pathlib import Path
 from typing import Any
 
-from appdirs import user_config_dir
+from .paths import user_config_dir
 
 from .authoring import normalize_provider_id
-from .resolver import ProjectRootNotFoundError, find_project_root
+from .root import ProjectRootNotFoundError, find_project_root
 
 # ---------------------------------------------------------------------------
 # Host and provider helpers

--- a/src/pysigil/core.py
+++ b/src/pysigil/core.py
@@ -17,8 +17,8 @@ from .errors import (
 )
 from .gui import events
 from .merge_policy import CORE_DEFAULTS, KeyPath, parse_key, read_env
+from .root import ProjectRootNotFoundError
 from .resolver import (
-    ProjectRootNotFoundError,
     project_settings_file,
     resolve_defaults,
     user_settings_file,

--- a/src/pysigil/gui/author.py
+++ b/src/pysigil/gui/author.py
@@ -9,13 +9,12 @@ from tkinter import filedialog, messagebox, ttk
 
 from ..authoring import DevLinkError, _dev_dir, link, normalize_provider_id
 from ..resolver import (
-    ProjectRootNotFoundError,
     default_provider_id,
     ensure_defaults_file,
     find_package_dir,
-    find_project_root,
     read_dist_name_from_pyproject,
 )
+from ..root import ProjectRootNotFoundError, find_project_root
 
 APP_TITLE = "Sigil – Register Package Defaults"
 

--- a/src/pysigil/io_config.py
+++ b/src/pysigil/io_config.py
@@ -4,12 +4,6 @@ import configparser
 from importlib import resources
 from pathlib import Path
 
-try:
-    from appdirs import user_config_dir  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - fallback
-    def user_config_dir(appname: str) -> str:
-        return str(Path.home() / ".config" / appname)
-
 
 class IniIOError(Exception):
     """Raised when an INI file cannot be read or written."""

--- a/src/pysigil/paths.py
+++ b/src/pysigil/paths.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+from importlib import resources as ilr
+from pathlib import Path
+
+from platformdirs import (
+    user_cache_dir as _ucache,
+    user_config_dir as _uc,
+    user_data_dir as _ud,
+)
+
+from .root import find_project_root
+
+# ---------------------------------------------------------------------------
+# User directories
+# ---------------------------------------------------------------------------
+
+def _app_name(default: str) -> str:
+    return os.getenv("SIGIL_APP_NAME", default)
+
+def user_config_dir(app_name: str = "pysigil") -> Path:
+    app = _app_name(app_name)
+    return Path(_uc(appname=app)).resolve()
+
+def user_data_dir(app_name: str = "pysigil") -> Path:
+    app = _app_name(app_name)
+    return Path(_ud(appname=app)).resolve()
+
+def user_cache_dir(app_name: str = "pysigil") -> Path:
+    app = _app_name(app_name)
+    return Path(_ucache(appname=app)).resolve()
+
+# ---------------------------------------------------------------------------
+# Project directories
+# ---------------------------------------------------------------------------
+def project_root(start: str | Path | None = None, **kw) -> Path:
+    env = os.getenv("SIGIL_ROOT")
+    if env:
+        return Path(env).expanduser().resolve()
+    return find_project_root(start=start, **kw)
+
+def project_config_dir(start: str | Path | None = None, **kw) -> Path:
+    return project_root(start, **kw) / ".sigil"
+
+def project_data_dir(start: str | Path | None = None, **kw) -> Path:
+    return project_config_dir(start, **kw) / "data"
+
+def project_cache_dir(start: str | Path | None = None, **kw) -> Path:
+    return project_config_dir(start, **kw) / "cache"
+
+# ---------------------------------------------------------------------------
+# Package-installed defaults
+# ---------------------------------------------------------------------------
+
+def default_config_dir(package: str = "pysigil") -> Path:
+    return Path(ilr.files(package)) / ".sigil"
+
+def default_data_dir(package: str = "pysigil") -> Path:
+    return default_config_dir(package) / "data"

--- a/src/pysigil/root.py
+++ b/src/pysigil/root.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+try:  # pragma: no cover - optional dependency
+    from pyprojroot import here
+except Exception:  # pragma: no cover - fallback
+    here = None  # type: ignore[assignment]
+
+
+class ProjectRootNotFoundError(RuntimeError):
+    """Raised when no project root can be located."""
+
+
+def _scan_for_markers(start: Path, markers: Iterable[str]) -> Path | None:
+    for path in [start, *start.parents]:
+        for marker in markers:
+            if (path / marker).exists():
+                return path
+    return None
+
+
+def find_project_root(
+    start: str | Path | None = None,
+    *,
+    strict: bool = True,
+    allow_ide: bool = False,  # reserved for future use
+) -> Path:
+    """Return the nearest project root.
+
+    The search prefers :mod:`pyprojroot` when available and falls back to
+    scanning upwards from ``start`` for a ``pyproject.toml`` file or ``.git``
+    directory.  ``strict=False`` returns the starting path when no root is
+    found instead of raising :class:`ProjectRootNotFoundError`.
+    """
+
+    if start is None:
+        start_path = Path.cwd()
+    else:
+        start_path = Path(start).expanduser().resolve()
+
+    # Try pyprojroot if present when no start is given
+    if start is None and here is not None:  # pragma: no branch - simple guard
+        try:
+            return Path(here()).resolve()
+        except Exception:
+            pass
+
+    markers = ["pyproject.toml", ".git"]
+    root = _scan_for_markers(start_path, markers)
+    if root is not None:
+        return root
+
+    if strict:
+        raise ProjectRootNotFoundError("No project root found")
+    return start_path

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -6,9 +6,9 @@ from pysigil.resolver import (
     default_provider_id,
     ensure_defaults_file,
     find_package_dir,
-    find_project_root,
     read_dist_name_from_pyproject,
 )
+from pysigil.root import find_project_root
 
 
 def write_pyproject(root: Path, name: str | None = None) -> None:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,7 @@
+from pysigil.paths import user_cache_dir, user_config_dir, user_data_dir
+
+
+def test_user_dirs_absolute() -> None:
+    assert user_config_dir().is_absolute()
+    assert user_data_dir().is_absolute()
+    assert user_cache_dir().is_absolute()

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import pytest
+
+from pysigil.root import ProjectRootNotFoundError, find_project_root
+
+
+def test_project_root_missing_raises(tmp_path: Path) -> None:
+    with pytest.raises(ProjectRootNotFoundError):
+        find_project_root(start=tmp_path)


### PR DESCRIPTION
## Summary
- add dedicated `root` and `paths` modules
- refactor resolver and clients to use new utilities
- introduce `paths` CLI helper and switch to platformdirs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0f4ab745c83289df8553d023ad503