### PR TITLE
test: isolate package defaults from dev links

### DIFF
--- a/tests/test_core_basic.py
+++ b/tests/test_core_basic.py
@@ -19,6 +19,7 @@ def test_package_defaults_read_only(tmp_path: Path, monkeypatch) -> None:
     (pkg / ".sigil" / "settings.ini").write_text("[pkgdefaults]\nfoo = 7\n")
     (pkg / "__init__.py").write_text("")
     monkeypatch.syspath_prepend(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
     user_dir = tmp_path / "user"
     s = Sigil("pkgdefaults", user_scope=user_dir)
     assert s.get_pref("foo") == 7


### PR DESCRIPTION
## Summary
- ensure `test_package_defaults_read_only` uses a temp config home so host dev links can't override package defaults

## Testing
- `pytest tests/test_core_basic.py::test_package_defaults_read_only -vv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3b2e73ce08328bf55529c21b5254f