### PR TITLE
Add provider metadata editing utilities

### DIFF
--- a/src/pysigil/settings_metadata.py
+++ b/src/pysigil/settings_metadata.py
@@ -496,6 +496,46 @@ def add_field_spec(path: Path, field: FieldSpec) -> ProviderSpec:
     return spec
 
 
+def update_field_spec(path: Path, field: FieldSpec) -> ProviderSpec:
+    """Replace an existing *field* in the provider spec stored at *path*."""
+
+    spec = load_provider_spec(path)
+    fields = list(spec.fields)
+    for idx, existing in enumerate(fields):
+        if existing.key == field.key:
+            fields[idx] = field
+            break
+    else:  # pragma: no cover - defensive
+        raise KeyError(f"unknown field {field.key!r}")
+    spec = ProviderSpec(
+        provider_id=spec.provider_id,
+        schema_version=spec.schema_version,
+        title=spec.title,
+        description=spec.description,
+        fields=fields,
+    )
+    save_provider_spec(path, spec)
+    return spec
+
+
+def remove_field_spec(path: Path, key: str) -> ProviderSpec:
+    """Remove the field identified by *key* from the provider spec at *path*."""
+
+    spec = load_provider_spec(path)
+    fields = [f for f in spec.fields if f.key != key]
+    if len(fields) == len(spec.fields):  # pragma: no cover - defensive
+        raise KeyError(f"unknown field {key!r}")
+    spec = ProviderSpec(
+        provider_id=spec.provider_id,
+        schema_version=spec.schema_version,
+        title=spec.title,
+        description=spec.description,
+        fields=fields,
+    )
+    save_provider_spec(path, spec)
+    return spec
+
+
 __all__ = [
     "BooleanAdapter",
     "FieldSpec",
@@ -510,6 +550,8 @@ __all__ = [
     "TYPE_REGISTRY",
     "TypeAdapter",
     "add_field_spec",
+    "update_field_spec",
+    "remove_field_spec",
     "load_provider_spec",
     "register_provider",
     "save_provider_spec",

--- a/tests/test_user_settings_metadata.py
+++ b/tests/test_user_settings_metadata.py
@@ -1,0 +1,25 @@
+from pysigil.settings_metadata import (
+    FieldSpec,
+    add_field_spec,
+    load_provider_spec,
+    register_provider,
+    remove_field_spec,
+    update_field_spec,
+)
+
+
+def test_register_add_edit_delete(tmp_path):
+    path = tmp_path / "user" / "my-pkg.json"
+    register_provider(path, "my-pkg", "1.0", title="my-pkg")
+
+    field = FieldSpec(key="alpha", type="string", label="Alpha")
+    add_field_spec(path, field)
+
+    updated = FieldSpec(key="alpha", type="string", label="Alpha 2")
+    update_field_spec(path, updated)
+    spec = load_provider_spec(path)
+    assert [f.label for f in spec.fields] == ["Alpha 2"]
+
+    remove_field_spec(path, "alpha")
+    spec = load_provider_spec(path)
+    assert spec.fields == ()


### PR DESCRIPTION
## Summary
- support updating and removing fields from provider specs
- cover register/add/edit/delete flow in a user directory example

## Testing
- `pytest tests/test_provider_registry.py tests/test_settings_metadata.py tests/test_user_settings_metadata.py`


------
https://chatgpt.com/codex/tasks/task_e_68a509178e8c8328bcb0b85a5e2f5877