### PR TITLE
Persist provider metadata and add roundtrip test

### DIFF
--- a/src/pysigil/settings_metadata.py
+++ b/src/pysigil/settings_metadata.py
@@ -445,11 +445,16 @@ class ProviderManager:
 # ---------------------------------------------------------------------------
 
 def save_provider_spec(path: Path, spec: ProviderSpec) -> None:
-    """Persist *spec* as JSON at *path*.
+    """Persist provider metadata and field definitions at *path*.
 
-    The file is written atomically by using a temporary file which is then
-    moved into place.
+    The provider's package-level information (such as ``provider_id`` and
+    ``schema_version``) along with its field specifications are written to
+    disk in a deterministic JSON format.  The file is written atomically by
+    using a temporary file which is then moved into place.  Parent directories
+    are created as needed so callers can provide paths in yet-to-exist
+    configuration roots.
     """
+
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")

--- a/tests/test_user_settings_metadata_roundtrip.py
+++ b/tests/test_user_settings_metadata_roundtrip.py
@@ -1,0 +1,36 @@
+from pysigil.settings_metadata import (
+    FieldSpec,
+    add_field_spec,
+    load_provider_spec,
+    register_provider,
+    remove_field_spec,
+    update_field_spec,
+)
+
+
+def test_register_add_update_remove(tmp_path):
+    path = tmp_path / "user" / "my-pkg.json"
+
+    # Register a provider and ensure package-level metadata is saved
+    register_provider(path, "my-pkg", "1.0", title="my-pkg")
+    spec = load_provider_spec(path)
+    assert spec.provider_id == "my-pkg"
+    assert spec.title == "my-pkg"
+    assert spec.fields == ()
+
+    # Add a field and verify it is persisted
+    field = FieldSpec(key="alpha", type="string", label="Alpha")
+    add_field_spec(path, field)
+    spec = load_provider_spec(path)
+    assert [f.label for f in spec.fields] == ["Alpha"]
+
+    # Update the field and verify changes are persisted
+    updated = FieldSpec(key="alpha", type="string", label="Alpha 2")
+    update_field_spec(path, updated)
+    spec = load_provider_spec(path)
+    assert [f.label for f in spec.fields] == ["Alpha 2"]
+
+    # Remove the field and ensure file reflects the deletion
+    remove_field_spec(path, "alpha")
+    spec = load_provider_spec(path)
+    assert spec.fields == ()


### PR DESCRIPTION
## Summary
- clarify save_provider_spec to persist provider metadata and create parent directories
- add roundtrip test exercising provider registration and field updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a54e53734c8328824fdf50b41713b3