### PR TITLE
Add orchestrator API with tests

### DIFF
--- a/src/pysigil/orchestrator.py
+++ b/src/pysigil/orchestrator.py
@@ -1,0 +1,444 @@
+"""High level orchestration layer for Sigil configuration.
+
+This module exposes a thin façade that ties together a specification
+backend (storing provider metadata) and the existing configuration
+backend.  It offers a small, UI agnostic API for managing provider
+metadata and reading/writing typed configuration values.  The
+implementation is deliberately compact but mirrors the design proposed in
+the accompanying user request so that it can grow organically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Dict, Literal, Protocol
+from uuid import uuid4
+
+from .authoring import normalize_provider_id
+from .settings_metadata import (
+    FieldSpec,
+    FieldValue,
+    ProviderManager,
+    ProviderSpec,
+    SigilBackend,
+    TYPE_REGISTRY,
+    save_provider_spec,
+)
+from .root import ProjectRootNotFoundError
+
+
+# ---------------------------------------------------------------------------
+# errors
+# ---------------------------------------------------------------------------
+
+
+class OrchestratorError(Exception):
+    """Base class for orchestrator specific errors."""
+
+
+class UnknownProviderError(OrchestratorError):
+    """Raised when a provider is requested that does not exist."""
+
+
+class UnknownFieldError(OrchestratorError):
+    """Raised when a field key is unknown."""
+
+
+class DuplicateProviderError(OrchestratorError):
+    """Raised when attempting to create a provider that already exists."""
+
+
+class DuplicateFieldError(OrchestratorError):
+    """Raised when attempting to add a field that already exists."""
+
+
+class ValidationError(OrchestratorError):
+    """Raised when value validation fails."""
+
+
+class PolicyError(OrchestratorError):
+    """Raised when the configuration policy prevents an operation."""
+
+
+class ConflictError(OrchestratorError):
+    """Raised when concurrent spec modifications conflict."""
+
+
+# ---------------------------------------------------------------------------
+# spec backend protocol + in-memory implementation
+# ---------------------------------------------------------------------------
+
+
+class SpecBackend(Protocol):
+    """Protocol describing the provider specification backend."""
+
+    def get_provider_ids(self) -> list[str]:
+        ...
+
+    def get_spec(self, provider_id: str) -> ProviderSpec:
+        ...
+
+    def save_spec(self, spec: ProviderSpec, *, expected_etag: str | None = None) -> str:
+        ...
+
+    def create_spec(self, spec: ProviderSpec) -> str:
+        ...
+
+    def delete_spec(self, provider_id: str) -> None:
+        ...
+
+    def etag(self, provider_id: str) -> str:
+        ...
+
+
+class InMemorySpecBackend:
+    """Simple ``SpecBackend`` storing data in memory.
+
+    The backend assigns a random *etag* to every stored specification so
+    that concurrent modification can be detected by the ``Orchestrator``.
+    """
+
+    def __init__(self) -> None:
+        self._specs: Dict[str, ProviderSpec] = {}
+        self._etags: Dict[str, str] = {}
+
+    def get_provider_ids(self) -> list[str]:  # pragma: no cover - trivial
+        return sorted(self._specs)
+
+    def get_spec(self, provider_id: str) -> ProviderSpec:
+        try:
+            return self._specs[provider_id]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise UnknownProviderError(provider_id) from exc
+
+    def save_spec(self, spec: ProviderSpec, *, expected_etag: str | None = None) -> str:
+        current = self._etags.get(spec.provider_id)
+        if expected_etag is not None and current is not None and expected_etag != current:
+            raise ConflictError(spec.provider_id)
+        etag = uuid4().hex
+        self._specs[spec.provider_id] = spec
+        self._etags[spec.provider_id] = etag
+        return etag
+
+    def create_spec(self, spec: ProviderSpec) -> str:
+        if spec.provider_id in self._specs:
+            raise DuplicateProviderError(spec.provider_id)
+        etag = uuid4().hex
+        self._specs[spec.provider_id] = spec
+        self._etags[spec.provider_id] = etag
+        return etag
+
+    def delete_spec(self, provider_id: str) -> None:
+        self._specs.pop(provider_id, None)
+        self._etags.pop(provider_id, None)
+
+    def etag(self, provider_id: str) -> str:
+        try:
+            return self._etags[provider_id]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise UnknownProviderError(provider_id) from exc
+
+
+# ---------------------------------------------------------------------------
+# orchestrator implementation
+# ---------------------------------------------------------------------------
+
+
+class Orchestrator:
+    """High level façade coordinating spec and config backends."""
+
+    def __init__(self, spec_backend: SpecBackend, config_backend: SigilBackend):
+        self.spec_backend = spec_backend
+        self.config_backend = config_backend
+
+    # ---- Provider / package metadata ----
+    def register_provider(
+        self,
+        provider_id: str,
+        *,
+        title: str | None = None,
+        description: str | None = None,
+    ) -> ProviderSpec:
+        pid = normalize_provider_id(provider_id)
+        spec = ProviderSpec(
+            provider_id=pid,
+            schema_version="0",
+            title=title,
+            description=description,
+        )
+        self.spec_backend.create_spec(spec)
+        return spec
+
+    def edit_provider(
+        self,
+        provider_id: str,
+        *,
+        title: str | None = None,
+        description: str | None = None,
+    ) -> ProviderSpec:
+        pid = normalize_provider_id(provider_id)
+        spec = self.spec_backend.get_spec(pid)
+        etag = self.spec_backend.etag(pid)
+        updated = replace(
+            spec,
+            title=spec.title if title is None else title,
+            description=spec.description if description is None else description,
+        )
+        self.spec_backend.save_spec(updated, expected_etag=etag)
+        return updated
+
+    def delete_provider(self, provider_id: str) -> None:
+        pid = normalize_provider_id(provider_id)
+        self.spec_backend.delete_spec(pid)
+
+    # ---- Field metadata ----
+    def add_field(
+        self,
+        provider_id: str,
+        *,
+        key: str,
+        type: str,
+        label: str | None = None,
+        description: str | None = None,
+    ) -> FieldSpec:
+        pid = normalize_provider_id(provider_id)
+        spec = self.spec_backend.get_spec(pid)
+        if key in {f.key for f in spec.fields}:
+            raise DuplicateFieldError(key)
+        field = FieldSpec(key=key, type=type, label=label, description=description)
+        new_spec = replace(spec, fields=tuple(spec.fields) + (field,))
+        etag = self.spec_backend.etag(pid)
+        self.spec_backend.save_spec(new_spec, expected_etag=etag)
+        mgr = ProviderManager(new_spec, self.config_backend)
+        try:  # ensure default section exists for user scope
+            mgr.init("user")
+        except ProjectRootNotFoundError as exc:  # pragma: no cover - defensive
+            raise PolicyError(str(exc)) from exc
+        return field
+
+    def edit_field(
+        self,
+        provider_id: str,
+        key: str,
+        *,
+        new_key: str | None = None,
+        new_type: str | None = None,
+        label: str | None = None,
+        description: str | None = None,
+        on_type_change: Literal["convert", "clear"] = "convert",
+    ) -> FieldSpec:
+        pid = normalize_provider_id(provider_id)
+        spec = self.spec_backend.get_spec(pid)
+        fields = list(spec.fields)
+        try:
+            index = next(i for i, f in enumerate(fields) if f.key == key)
+        except StopIteration as exc:
+            raise UnknownFieldError(key) from exc
+
+        old_field = fields[index]
+        nk = new_key or key
+        nt = new_type or old_field.type
+
+        if nk != key and nk in {f.key for f in fields}:
+            raise DuplicateFieldError(nk)
+
+        fields[index] = FieldSpec(
+            key=nk,
+            type=nt,
+            label=old_field.label if label is None else label,
+            description=old_field.description if description is None else description,
+        )
+
+        new_spec = replace(spec, fields=tuple(fields))
+        etag = self.spec_backend.etag(pid)
+        self.spec_backend.save_spec(new_spec, expected_etag=etag)
+
+        raw_map, source_map = self.config_backend.read_merged(pid)
+        raw = raw_map.get(key)
+        source = source_map.get(key)
+        if raw is not None and source is not None:
+            scope = source.split("-")[0]
+            target = self.config_backend.write_target_for(pid)
+            if nk != key:
+                self.config_backend.write_key(pid, nk, raw, scope=scope, target_kind=target)
+                self.config_backend.remove_key(pid, key, scope=scope, target_kind=target)
+                raw_map[nk] = raw
+                raw = raw_map.get(nk)
+            if nt != old_field.type:
+                if on_type_change == "convert":
+                    adapter = TYPE_REGISTRY[nt]
+                    value = adapter.parse(raw)
+                    raw_new = adapter.serialize(value)
+                    self.config_backend.write_key(
+                        pid, nk, raw_new, scope=scope, target_kind=target
+                    )
+                elif on_type_change == "clear":
+                    self.config_backend.remove_key(pid, nk, scope=scope, target_kind=target)
+
+        return fields[index]
+
+    def delete_field(
+        self,
+        provider_id: str,
+        key: str,
+        *,
+        remove_values: bool = False,
+        scopes: tuple[str, ...] = ("user", "project"),
+    ) -> None:
+        pid = normalize_provider_id(provider_id)
+        spec = self.spec_backend.get_spec(pid)
+        fields = [f for f in spec.fields if f.key != key]
+        if len(fields) == len(spec.fields):
+            raise UnknownFieldError(key)
+        new_spec = replace(spec, fields=tuple(fields))
+        etag = self.spec_backend.etag(pid)
+        self.spec_backend.save_spec(new_spec, expected_etag=etag)
+
+        if remove_values:
+            target = self.config_backend.write_target_for(pid)
+            for scope in scopes:
+                try:
+                    self.config_backend.remove_key(
+                        pid, key, scope=scope, target_kind=target
+                    )
+                except ProjectRootNotFoundError as exc:  # pragma: no cover - defensive
+                    raise PolicyError(str(exc)) from exc
+
+    # ---- Discovery ----
+    def list_providers(self) -> list[str]:
+        return self.spec_backend.get_provider_ids()
+
+    def list_fields(self, provider_id: str) -> list[FieldSpec]:
+        pid = normalize_provider_id(provider_id)
+        spec = self.spec_backend.get_spec(pid)
+        return list(spec.fields)
+
+    def find_untracked_keys(self, provider_id: str) -> list[str]:
+        pid = normalize_provider_id(provider_id)
+        spec = self.spec_backend.get_spec(pid)
+        raw_map, _ = self.config_backend.read_merged(pid)
+        tracked = {f.key for f in spec.fields}
+        return sorted(set(raw_map) - tracked)
+
+    def adopt_untracked(self, provider_id: str, mapping: dict[str, str]) -> list[FieldSpec]:
+        added: list[FieldSpec] = []
+        for key, type in mapping.items():
+            added.append(self.add_field(provider_id, key=key, type=type))
+        return added
+
+    # ---- Values ----
+    def _manager(self, provider_id: str) -> ProviderManager:
+        pid = normalize_provider_id(provider_id)
+        spec = self.spec_backend.get_spec(pid)
+        return ProviderManager(spec, self.config_backend)
+
+    def get_effective(self, provider_id: str) -> dict[str, FieldValue]:
+        return self._manager(provider_id).effective()
+
+    def set_value(
+        self,
+        provider_id: str,
+        key: str,
+        value: object,
+        *,
+        scope: Literal["user", "project"] = "user",
+    ) -> None:
+        mgr = self._manager(provider_id)
+        try:
+            mgr.set(key, value, scope=scope)
+        except (TypeError, ValueError) as exc:
+            raise ValidationError(str(exc)) from exc
+        except ProjectRootNotFoundError as exc:
+            raise PolicyError(str(exc)) from exc
+
+    def clear_value(
+        self,
+        provider_id: str,
+        key: str,
+        *,
+        scope: Literal["user", "project"] = "user",
+    ) -> None:
+        mgr = self._manager(provider_id)
+        try:
+            mgr.clear(key, scope=scope)
+        except ProjectRootNotFoundError as exc:
+            raise PolicyError(str(exc)) from exc
+
+    def set_many(
+        self,
+        provider_id: str,
+        updates: dict[str, object],
+        *,
+        scope: Literal["user", "project"] = "user",
+        atomic: bool = True,
+    ) -> None:
+        mgr = self._manager(provider_id)
+        if atomic:
+            # Validate first
+            fields = mgr._fields  # pylint: disable=protected-access
+            for key, value in updates.items():
+                field = fields.get(key)
+                if field is None:
+                    raise UnknownFieldError(key)
+                adapter = TYPE_REGISTRY[field.type]
+                try:
+                    adapter.validate(value, field)
+                except (TypeError, ValueError) as exc:
+                    raise ValidationError(str(exc)) from exc
+        for key, value in updates.items():
+            mgr.set(key, value, scope=scope)
+
+    def validate_value(self, provider_id: str, key: str, value: object) -> None:
+        mgr = self._manager(provider_id)
+        field = mgr._field_for(key)  # pylint: disable=protected-access
+        adapter = TYPE_REGISTRY[field.type]
+        try:
+            adapter.validate(value, field)
+        except (TypeError, ValueError) as exc:
+            raise ValidationError(str(exc)) from exc
+
+    def validate_all(self, provider_id: str) -> dict[str, str | None]:
+        pid = normalize_provider_id(provider_id)
+        spec = self.spec_backend.get_spec(pid)
+        raw_map, _ = self.config_backend.read_merged(pid)
+        result: dict[str, str | None] = {}
+        for field in spec.fields:
+            adapter = TYPE_REGISTRY[field.type]
+            raw = raw_map.get(field.key)
+            try:
+                adapter.parse(raw)
+            except Exception as exc:  # pragma: no cover - defensive
+                result[field.key] = str(exc)
+            else:
+                result[field.key] = None
+        return result
+
+    # ---- Spec persistence ----
+    def export_spec(self, provider_id: str, dest: str | Path) -> Path:
+        pid = normalize_provider_id(provider_id)
+        spec = self.spec_backend.get_spec(pid)
+        path = Path(dest)
+        save_provider_spec(path, spec)
+        return path
+
+    def reload_spec(self, provider_id: str) -> ProviderSpec:
+        pid = normalize_provider_id(provider_id)
+        return self.spec_backend.get_spec(pid)
+
+
+__all__ = [
+    "Orchestrator",
+    "SpecBackend",
+    "InMemorySpecBackend",
+    # errors
+    "OrchestratorError",
+    "UnknownProviderError",
+    "UnknownFieldError",
+    "DuplicateProviderError",
+    "DuplicateFieldError",
+    "ValidationError",
+    "PolicyError",
+    "ConflictError",
+]
+

--- a/tests/manual_orchestrator.py
+++ b/tests/manual_orchestrator.py
@@ -1,0 +1,42 @@
+"""Manual end-to-end exercises for the orchestrator.
+
+Running this module as a script will create temporary configuration files
+and demonstrate some of the key features of :class:`~pysigil.orchestrator.Orchestrator`.
+"""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from pysigil.orchestrator import InMemorySpecBackend, Orchestrator
+from pysigil.settings_metadata import IniFileBackend
+
+
+def manual_demo() -> None:
+    with TemporaryDirectory() as tmp:
+        base = Path(tmp)
+        backend = IniFileBackend(
+            user_dir=base / "user",
+            project_dir=base / "proj",
+            host="host",
+        )
+        spec_backend = InMemorySpecBackend()
+        orch = Orchestrator(spec_backend, backend)
+
+        orch.register_provider("demo", title="Demo")
+        orch.add_field("demo", key="greeting", type="string", label="Greeting")
+        orch.set_value("demo", "greeting", "hello")
+        print("Effective after set:", orch.get_effective("demo"))
+
+        orch.edit_field("demo", "greeting", new_key="salutation")
+        print("After rename:", orch.get_effective("demo"))
+
+        file_path = base / "user" / "demo" / "settings.ini"
+        print("Stored file contents:\n", file_path.read_text())
+
+        orch.delete_field("demo", "salutation", remove_values=True)
+        print("After delete:", orch.get_effective("demo"))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    manual_demo()
+

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,102 @@
+"""Automated tests for the :mod:`pysigil.orchestrator` module."""
+
+from pathlib import Path
+
+import pytest
+
+from pysigil.orchestrator import (
+    InMemorySpecBackend,
+    Orchestrator,
+    ValidationError,
+)
+from pysigil.settings_metadata import IniFileBackend
+
+
+def _make_orch(tmp_path: Path) -> Orchestrator:
+    backend = IniFileBackend(
+        user_dir=tmp_path / "user",
+        project_dir=tmp_path / "proj",
+        host="host",
+    )
+    spec_backend = InMemorySpecBackend()
+    return Orchestrator(spec_backend, backend)
+
+
+def test_register_add_set_get(tmp_path: Path) -> None:
+    orch = _make_orch(tmp_path)
+    orch.register_provider("my-pkg", title="My Package")
+    orch.add_field("my-pkg", key="retries", type="integer", label="Retries")
+    orch.set_value("my-pkg", "retries", 5)
+    eff = orch.get_effective("my-pkg")
+    assert eff["retries"].value == 5
+    assert eff["retries"].source == "user"
+
+
+def test_edit_field_rename_migrates_value(tmp_path: Path) -> None:
+    orch = _make_orch(tmp_path)
+    orch.register_provider("pkg")
+    orch.add_field("pkg", key="alpha", type="string")
+    orch.set_value("pkg", "alpha", "one")
+    orch.edit_field("pkg", "alpha", new_key="beta")
+    eff = orch.get_effective("pkg")
+    assert "beta" in eff and eff["beta"].value == "one"
+    path = tmp_path / "user" / "pkg" / "settings.ini"
+    assert path.read_text().strip().endswith("beta = one")
+
+
+def test_edit_field_type_change_convert(tmp_path: Path) -> None:
+    orch = _make_orch(tmp_path)
+    orch.register_provider("pkg")
+    orch.add_field("pkg", key="num", type="string")
+    orch.set_value("pkg", "num", "42")
+    orch.edit_field("pkg", "num", new_type="integer", on_type_change="convert")
+    eff = orch.get_effective("pkg")
+    assert eff["num"].value == 42
+
+
+def test_delete_field_removes_values(tmp_path: Path) -> None:
+    orch = _make_orch(tmp_path)
+    orch.register_provider("pkg")
+    orch.add_field("pkg", key="alpha", type="string")
+    orch.set_value("pkg", "alpha", "x")
+    orch.delete_field("pkg", "alpha", remove_values=True)
+    assert orch.list_fields("pkg") == []
+    path = tmp_path / "user" / "pkg" / "settings.ini"
+    assert "alpha" not in path.read_text()
+
+
+def test_find_and_adopt_untracked(tmp_path: Path) -> None:
+    orch = _make_orch(tmp_path)
+    orch.register_provider("pkg")
+    target = orch.config_backend.write_target_for("pkg")
+    orch.config_backend.write_key(
+        "pkg", "foo", "bar", scope="user", target_kind=target
+    )
+    assert orch.find_untracked_keys("pkg") == ["foo"]
+    orch.adopt_untracked("pkg", {"foo": "string"})
+    eff = orch.get_effective("pkg")
+    assert eff["foo"].value == "bar"
+
+
+def test_validate_all_reports_errors(tmp_path: Path) -> None:
+    orch = _make_orch(tmp_path)
+    orch.register_provider("pkg")
+    orch.add_field("pkg", key="num", type="integer")
+    target = orch.config_backend.write_target_for("pkg")
+    orch.config_backend.write_key(
+        "pkg", "num", "oops", scope="user", target_kind=target
+    )
+    errors = orch.validate_all("pkg")
+    assert errors["num"] is not None
+
+
+def test_set_many_atomic(tmp_path: Path) -> None:
+    orch = _make_orch(tmp_path)
+    orch.register_provider("pkg")
+    orch.add_field("pkg", key="a", type="integer")
+    orch.add_field("pkg", key="b", type="integer")
+    with pytest.raises(ValidationError):
+        orch.set_many("pkg", {"a": 1, "b": "bad"}, atomic=True)
+    eff = orch.get_effective("pkg")
+    assert eff["a"].value is None and eff["b"].value is None
+


### PR DESCRIPTION
## Summary
- add orchestrator module coordinating spec backend with INI config backend
- provide in-memory spec backend for tests and demos
- add automated and manual tests covering core orchestrator flows

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6523231948328bb08447216d82caf