### PR TITLE
Refactor spec and INI backends

### DIFF
--- a/tests/manual_orchestrator.py
+++ b/tests/manual_orchestrator.py
@@ -8,10 +8,9 @@ the :class:`~pysigil.orchestrator.Orchestrator`.
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from pysigil.orchestrator import InMemorySpecBackend, Orchestrator
-from pysigil.settings_metadata import IniFileBackend
+from pysigil.orchestrator import Orchestrator
 from pysigil.paths import user_config_dir
-from pysigil.settings_metadata import IniFileBackend
+from pysigil.settings_metadata import InMemorySpecBackend, IniFileBackend
 
 
 def manual_demo() -> None:
@@ -25,7 +24,7 @@ def manual_demo() -> None:
             project_dir=project_dir,
             host="host",
         )
-        spec_backend = IniFileBackend #InMemorySpecBackend()
+        spec_backend = InMemorySpecBackend()
         orch = Orchestrator(spec_backend, backend)
 
         # Register a provider (project) and add three fields

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -4,12 +4,8 @@ from pathlib import Path
 
 import pytest
 
-from pysigil.orchestrator import (
-    InMemorySpecBackend,
-    Orchestrator,
-    ValidationError,
-)
-from pysigil.settings_metadata import IniFileBackend
+from pysigil.orchestrator import Orchestrator, ValidationError
+from pysigil.settings_metadata import InMemorySpecBackend, IniFileBackend
 
 
 def _make_orch(tmp_path: Path) -> Orchestrator:


### PR DESCRIPTION
## Summary
- move spec backend protocol and in-memory implementation into settings_metadata
- streamline orchestrator to only orchestrate existing backends
- refine IniFileBackend path handling

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/orchestrator.py src/pysigil/settings_metadata.py tests/test_orchestrator.py tests/manual_orchestrator.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a66a7eb7fc8328b789da78109dbe0c