### PR TITLE
Store spec metadata with provider config

### DIFF
--- a/src/pysigil/settings_metadata.py
+++ b/src/pysigil/settings_metadata.py
@@ -271,8 +271,8 @@ class InMemorySpecBackend:
 class IniSpecBackend:
     """Persist provider specifications in simple INI files.
 
-    Provider metadata is stored in ``<base>/<provider_id>.ini`` where the
-    ``__meta__`` section holds package level information and each field is
+    Provider metadata is stored in ``<base>/<provider_id>/metadata.ini`` where
+    the ``__meta__`` section holds package level information and each field is
     represented by a ``field:<key>`` section with ``type``, ``label`` and
     ``description`` keys.  An in-memory ``etag`` is maintained for conflict
     detection in the same manner as :class:`InMemorySpecBackend`.
@@ -291,7 +291,7 @@ class IniSpecBackend:
 
     # ------------------------------------------------------------ helpers
     def _path(self, provider_id: str) -> Path:
-        return self.base_dir / f"{provider_id}.ini"
+        return self.base_dir / provider_id / "metadata.ini"
 
     def _write(self, path: Path, spec: ProviderSpec) -> None:
         parser = configparser.ConfigParser()
@@ -345,7 +345,9 @@ class IniSpecBackend:
 
     # -------------------------------------------------------------- API
     def get_provider_ids(self) -> list[str]:  # pragma: no cover - trivial
-        return sorted(p.stem for p in self.base_dir.glob("*.ini"))
+        return sorted(
+            p.name for p in self.base_dir.iterdir() if (p / "metadata.ini").exists()
+        )
 
     def get_spec(self, provider_id: str) -> ProviderSpec:
         path = self._path(provider_id)

--- a/tests/manual_orchestrator.py
+++ b/tests/manual_orchestrator.py
@@ -30,9 +30,9 @@ def manual_demo() -> None:
         orch.add_field("demo", key="beta", type="integer", label="Beta")
         orch.add_field("demo", key="gamma", type="boolean", label="Gamma")
 
-        # Set some values in user and project scopes
+        # Set some values in user scope
         orch.set_value("demo", "alpha", "hello")
-        orch.set_value("demo", "beta", 42, scope="project")
+        orch.set_value("demo", "beta", 42)
         orch.set_value("demo", "gamma", True)
 
         #orch.set_value("demo", "gamma", "NOT A BOOL") #errors as expected
@@ -50,9 +50,9 @@ def manual_demo() -> None:
         print("Updated provider title:", spec.title)
 
         user_file = user_dir / "demo" / "settings.ini"
-        project_file = project_dir / "demo" / "settings.ini"
+        spec_file = user_dir / "demo" / "metadata.ini"
         print("User file contents:\n", user_file.read_text())
-        print("Project file contents:\n", project_file.read_text())
+        print("Metadata file contents:\n", spec_file.read_text())
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution


### PR DESCRIPTION
## Summary
- save provider metadata in `<provider>/metadata.ini`
- update manual orchestrator demo to write sample data to user scope

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/settings_metadata.py tests/manual_orchestrator.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e246d8ac83289ba6fa3d33cbf0d6