### PR TITLE
Store project configs at .sigil root and allow default scope edits

### DIFF
--- a/src/pysigil/orchestrator.py
+++ b/src/pysigil/orchestrator.py
@@ -271,7 +271,7 @@ class Orchestrator:
         key: str,
         value: object,
         *,
-        scope: Literal["user", "project"] = "user",
+        scope: Literal["user", "project", "default"] = "user",
     ) -> None:
         mgr = self._manager(provider_id)
         try:
@@ -286,7 +286,7 @@ class Orchestrator:
         provider_id: str,
         key: str,
         *,
-        scope: Literal["user", "project"] = "user",
+        scope: Literal["user", "project", "default"] = "user",
     ) -> None:
         mgr = self._manager(provider_id)
         try:
@@ -299,7 +299,7 @@ class Orchestrator:
         provider_id: str,
         updates: dict[str, object],
         *,
-        scope: Literal["user", "project"] = "user",
+        scope: Literal["user", "project", "default"] = "user",
         atomic: bool = True,
     ) -> None:
         mgr = self._manager(provider_id)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,8 +35,7 @@ def test_precedence(monkeypatch, tmp_path: Path) -> None:
     (user_dir / "pkg").mkdir()
     (user_dir / "pkg" / "settings.ini").write_text("[pkg]\na=1\n")
     (user_dir / "pkg" / "settings-local-host.ini").write_text("[pkg]\na=2\n")
-    proj_dir = project_root / ".sigil" / "pkg"
-    proj_dir.mkdir(parents=True)
+    proj_dir = project_root / ".sigil"
     (proj_dir / "settings.ini").write_text("[pkg]\na=3\n")
     (proj_dir / "settings-local-host.ini").write_text("[pkg]\na=4\n")
     data = cfg.load("pkg")
@@ -67,8 +66,7 @@ def test_host_filtering(monkeypatch, tmp_path: Path) -> None:
     (user_dir / "pkg").mkdir()
     (user_dir / "pkg" / "settings-local-host.ini").write_text("[pkg]\nx=1\n")
     (user_dir / "pkg" / "settings-local-other.ini").write_text("[pkg]\nx=2\n")
-    proj_dir = project_root / ".sigil" / "pkg"
-    proj_dir.mkdir(parents=True)
+    proj_dir = project_root / ".sigil"
     (proj_dir / "settings-local-host.ini").write_text("[pkg]\ny=3\n")
     (proj_dir / "settings-local-other.ini").write_text("[pkg]\ny=4\n")
     data = cfg.load("pkg")
@@ -80,7 +78,7 @@ def test_gitignore_idempotent(monkeypatch, tmp_path: Path, capsys) -> None:
     _run_cli(["config", "gitignore", "--init", "--auto"], capsys)
     _run_cli(["config", "gitignore", "--init", "--auto"], capsys)
     content = (project_root / ".gitignore").read_text().splitlines()
-    assert content == [".sigil/*/settings-local*"]
+    assert content == [".sigil/settings-local*"]
 
 
 def test_cli_roundtrip(monkeypatch, tmp_path: Path, capsys) -> None:
@@ -88,7 +86,7 @@ def test_cli_roundtrip(monkeypatch, tmp_path: Path, capsys) -> None:
     _run_cli(["config", "init", "--provider", "pkg", "--scope", "user"], capsys)
     _run_cli(["config", "init", "--provider", "pkg", "--scope", "project", "--auto"], capsys)
     (user_dir / "pkg" / "settings.ini").write_text("[pkg]\nkey=user\n")
-    proj_dir = project_root / ".sigil" / "pkg"
+    proj_dir = project_root / ".sigil"
     (proj_dir / "settings.ini").write_text("[pkg]\nkey=project\n")
     res = _run_cli(["config", "show", "--provider", "pkg", "--as", "json", "--auto"], capsys)
     assert res.exit_code == 0

--- a/tests/test_settings_metadata.py
+++ b/tests/test_settings_metadata.py
@@ -65,9 +65,9 @@ def test_ini_file_backend(tmp_path):
     backend = IniFileBackend(user_dir=user_dir, project_dir=project_dir, host="host")
 
     write_sections(user_dir / "demo" / "settings.ini", {"demo": {"alpha": "u"}})
-    write_sections(project_dir / "demo" / "settings.ini", {"demo": {"alpha": "p", "beta": "p"}})
+    write_sections(project_dir / "settings.ini", {"demo": {"alpha": "p", "beta": "p"}})
     write_sections(
-        project_dir / "demo" / "settings-local-host.ini", {"demo": {"beta": "pl"}}
+        project_dir / "settings-local-host.ini", {"demo": {"beta": "pl"}}
     )
 
     raw, src = backend.read_merged("demo")


### PR DESCRIPTION
## Summary
- store project-level settings directly under `.sigil/` instead of per-package subdirectories
- allow orchestrator and backend to read/write default scope when a dev link is present
- update tests for new project layout and default scope editing

## Testing
- `pre-commit run --files src/pysigil/config.py src/pysigil/settings_metadata.py src/pysigil/orchestrator.py tests/test_config.py tests/test_orchestrator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8e90adec083288bb8eff528d88e23