### PR TITLE
Fix configuration scope precedence

### DIFF
--- a/src/pysigil/settings_metadata.py
+++ b/src/pysigil/settings_metadata.py
@@ -169,7 +169,13 @@ class FieldValue:
     """Parsed field value along with provenance information."""
 
     value: Any | None
-    source: Literal["user", "user-local", "project", "project-local"] | None = None
+    source: Literal[
+        "user",
+        "user-local",
+        "project",
+        "project-local",
+        "default",
+    ] | None = None
     raw: str | None = None
 
 ##########################
@@ -533,14 +539,14 @@ class IniFileBackend:
         raise ValueError(f"unknown scope {scope!r}")  # pragma: no cover - defensive
 
     def _iter_read_paths(self, provider_id: str) -> Iterable[tuple[str, Path]]:
-        yield "user", self.user_dir / provider_id / "settings.ini"
-        yield "user-local", self.user_dir / provider_id / f"settings-local-{self.host}.ini"
-        if self.project_dir is not None:
-            yield "project", self.project_dir / "settings.ini"
-            yield "project-local", self.project_dir / f"settings-local-{self.host}.ini"
         dl = get_dev_link(provider_id)
         if dl is not None and dl.defaults_path.is_file():
             yield "default", dl.defaults_path
+        if self.project_dir is not None:
+            yield "project", self.project_dir / "settings.ini"
+            yield "project-local", self.project_dir / f"settings-local-{self.host}.ini"
+        yield "user", self.user_dir / provider_id / "settings.ini"
+        yield "user-local", self.user_dir / provider_id / f"settings-local-{self.host}.ini"
 
     # ------------------------------------------------------------------
     # SigilBackend API

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -140,3 +140,35 @@ def test_metadata_stored_in_defaults(tmp_path: Path, monkeypatch) -> None:
     assert meta_path.exists()
     assert "field:alpha" in meta_path.read_text()
 
+
+def test_scope_precedence(tmp_path: Path, monkeypatch) -> None:
+    import pysigil.authoring as auth
+
+    user_dir = tmp_path / "user"
+    dev_defaults = tmp_path / "pkg" / ".sigil" / "settings.ini"
+    dev_defaults.parent.mkdir(parents=True)
+    dev_defaults.write_text("[pkg]\n", encoding="utf-8")
+    monkeypatch.setattr(auth, "user_config_dir", lambda app: str(user_dir))
+    auth.link("pkg", dev_defaults, validate=False)
+
+    orch = _make_orch(tmp_path)
+    orch.register_provider("pkg")
+    orch.add_field("pkg", key="key", type="string")
+
+    orch.set_value("pkg", "key", "default", scope="default")
+    orch.set_value("pkg", "key", "project", scope="project")
+    orch.set_value("pkg", "key", "user", scope="user")
+    eff = orch.get_effective("pkg")
+    assert eff["key"].value == "user"
+    assert eff["key"].source == "user"
+
+    orch.clear_value("pkg", "key", scope="user")
+    eff = orch.get_effective("pkg")
+    assert eff["key"].value == "project"
+    assert eff["key"].source == "project"
+
+    orch.clear_value("pkg", "key", scope="project")
+    eff = orch.get_effective("pkg")
+    assert eff["key"].value == "default"
+    assert eff["key"].source == "default"
+

--- a/tests/test_settings_metadata.py
+++ b/tests/test_settings_metadata.py
@@ -71,8 +71,8 @@ def test_ini_file_backend(tmp_path):
     )
 
     raw, src = backend.read_merged("demo")
-    assert raw == {"alpha": "p", "beta": "pl"}
-    assert src == {"alpha": "project", "beta": "project-local"}
+    assert raw == {"alpha": "u", "beta": "pl"}
+    assert src == {"alpha": "user", "beta": "project-local"}
 
     backend.ensure_section("demo", scope="user", target_kind="settings.ini")
     backend.write_key("demo", "gamma", "42", scope="user", target_kind="settings.ini")


### PR DESCRIPTION
## Summary
- ensure default configuration values no longer override project and user settings
- record "default" as a valid source for field values
- add regression tests covering scope precedence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f543c47c83288ebe9e6d2ef1d618