### PR TITLE
Fix configuration scope precedence

### DIFF
--- a/src/pysigil/config.py
+++ b/src/pysigil/config.py
@@ -9,6 +9,7 @@ from .paths import user_config_dir
 
 from .authoring import normalize_provider_id
 from .root import ProjectRootNotFoundError, find_project_root
+from .merge_policy import PRECEDENCE_PROJECT_WINS
 
 # ---------------------------------------------------------------------------
 # Host and provider helpers
@@ -68,10 +69,13 @@ def load(provider_id: str, *, auto: bool = True) -> dict[str, Any]:
     pid = normalize_provider_id(provider_id)
     h = host_id()
     acc: dict[str, Any] = {}
-    for f in user_files(pid, h):
-        acc = merge_ini_section(acc, f, section=pid)
-    for f in project_files(pid, h, auto=auto):
-        acc = merge_ini_section(acc, f, section=pid)
+    for scope in reversed(PRECEDENCE_PROJECT_WINS):
+        if scope == "user":
+            for f in user_files(pid, h):
+                acc = merge_ini_section(acc, f, section=pid)
+        elif scope == "project":
+            for f in project_files(pid, h, auto=auto):
+                acc = merge_ini_section(acc, f, section=pid)
     return acc
 
 

--- a/src/pysigil/core.py
+++ b/src/pysigil/core.py
@@ -16,7 +16,14 @@ from .errors import (
     UnknownScopeError,
 )
 from .gui import events
-from .merge_policy import CORE_DEFAULTS, KeyPath, parse_key, read_env
+from .merge_policy import (
+    CORE_DEFAULTS,
+    KeyPath,
+    PRECEDENCE_PROJECT_WINS,
+    PRECEDENCE_USER_WINS,
+    parse_key,
+    read_env,
+)
 from .root import ProjectRootNotFoundError
 from .resolver import (
     project_settings_file,
@@ -40,10 +47,6 @@ def _backend_for(path: Path):
 logger = logging.getLogger("pysigil")
 
 KEY_JOIN_CHAR = "_"
-
-
-PRECEDENCE_USER_WINS = ("env", "user", "project", "default", "core")
-PRECEDENCE_PROJECT_WINS = ("env", "project", "user", "default", "core")
 
 
 class Sigil:

--- a/src/pysigil/merge_policy.py
+++ b/src/pysigil/merge_policy.py
@@ -30,3 +30,8 @@ def read_env(app_name: str) -> MutableMapping[KeyPath, str]:
 
 
 CORE_DEFAULTS = {"pysigil": {"policy": "project_over_user"}}
+
+# Precedence orders from highest to lowest scope
+PRECEDENCE_USER_WINS = ("env", "user", "project", "default", "core")
+PRECEDENCE_PROJECT_WINS = ("env", "project", "user", "default", "core")
+


### PR DESCRIPTION
## Summary
- centralize scope precedence constants
- ensure project-level settings override user configuration
- track environment as a possible field value source

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f543c47c83288ebe9e6d2ef1d618