### PR TITLE
Introduce centralized scope policy manager

### DIFF
--- a/src/pysigil/__init__.py
+++ b/src/pysigil/__init__.py
@@ -1,4 +1,5 @@
 from .core import Sigil, SigilError
 from .merge_policy import parse_key
+from .policy import policy
 
-__all__ = ["Sigil", "SigilError", "parse_key"]
+__all__ = ["Sigil", "SigilError", "parse_key", "policy"]

--- a/src/pysigil/api.py
+++ b/src/pysigil/api.py
@@ -17,7 +17,7 @@ from .errors import (
     ValidationError,
 )
 from .orchestrator import Orchestrator
-from .config import target_path as cfg_target_path
+from .policy import policy
 from .settings_metadata import FieldSpec, FieldValue, ProviderSpec
 
 __all__ = [
@@ -345,4 +345,4 @@ class ProviderHandle:
     ) -> Path:
 
         """Return the file path used for *scope* writes."""
-        return cfg_target_path(self.provider_id, scope)
+        return policy.path(scope, self.provider_id)

--- a/src/pysigil/config.py
+++ b/src/pysigil/config.py
@@ -10,7 +10,7 @@ from .paths import user_config_dir
 
 from .authoring import normalize_provider_id
 from .root import ProjectRootNotFoundError, find_project_root
-from .merge_policy import PRECEDENCE_PROJECT_WINS
+from .policy import policy
 from .io_config import IniIOError
 
 
@@ -75,7 +75,7 @@ def load(provider_id: str, *, auto: bool = True) -> dict[str, Any]:
     h = host_id()
     acc: dict[str, Any] = {}
     root = _project_dir(auto)
-    for scope in reversed(PRECEDENCE_PROJECT_WINS):
+    for scope in reversed(policy.precedence("project_over_user")):
         if scope == "user":
             files = [Path(user_config_dir("sigil")) / pid / "settings.ini"]
         elif scope == "user-local":

--- a/src/pysigil/core.py
+++ b/src/pysigil/core.py
@@ -16,14 +16,8 @@ from .errors import (
     UnknownScopeError,
 )
 from .gui import events
-from .merge_policy import (
-    CORE_DEFAULTS,
-    KeyPath,
-    PRECEDENCE_PROJECT_WINS,
-    PRECEDENCE_USER_WINS,
-    parse_key,
-    read_env,
-)
+from .merge_policy import KeyPath, parse_key, read_env
+from .policy import CORE_DEFAULTS, policy
 from .root import ProjectRootNotFoundError
 from .resolver import (
     project_settings_file,
@@ -226,7 +220,7 @@ class Sigil:
         return path[1:] if self._is_ours(path) else path
 
     def _order_for(self, keypath: KeyPath) -> tuple[str, ...]:
-        return PRECEDENCE_PROJECT_WINS
+        return policy.precedence("project_over_user")
 
     def _value_from_scope(self, scope: str, key: KeyPath) -> str | None:
         if scope == "env":

--- a/src/pysigil/merge_policy.py
+++ b/src/pysigil/merge_policy.py
@@ -28,26 +28,3 @@ def read_env(app_name: str) -> MutableMapping[KeyPath, str]:
             result[parse_key(raw)] = value
     return result
 
-
-CORE_DEFAULTS = {"pysigil": {"policy": "project_over_user"}}
-
-# Precedence orders from highest to lowest scope
-PRECEDENCE_USER_WINS = (
-    "env",
-    "user-local",
-    "user",
-    "project-local",
-    "project",
-    "default",
-    "core",
-)
-PRECEDENCE_PROJECT_WINS = (
-    "env",
-    "project-local",
-    "project",
-    "user-local",
-    "user",
-    "default",
-    "core",
-)
-

--- a/src/pysigil/policy.py
+++ b/src/pysigil/policy.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+from .errors import UnknownScopeError, SigilWriteError
+
+# Predefined defaults for the core scope
+CORE_DEFAULTS = {"pysigil": {"policy": "project_over_user"}}
+
+# Precedence orders from highest to lowest scope
+PRECEDENCE_USER_WINS: Tuple[str, ...] = (
+    "env",
+    "user-local",
+    "user",
+    "project-local",
+    "project",
+    "default",
+    "core",
+)
+PRECEDENCE_PROJECT_WINS: Tuple[str, ...] = (
+    "env",
+    "project-local",
+    "project",
+    "user-local",
+    "user",
+    "default",
+    "core",
+)
+
+
+@dataclass(frozen=True)
+class Scope:
+    """Representation of a configuration scope."""
+
+    name: str
+    writable: bool = False
+
+
+class ScopePolicy:
+    """Manager providing policy information for configuration scopes."""
+
+    def __init__(self, scopes: Iterable[Scope]):
+        self._scopes: List[Scope] = list(scopes)
+        self._by_name = {s.name: s for s in self._scopes}
+
+    @property
+    def scopes(self) -> List[str]:
+        """Ordered list of known scope names."""
+        return [s.name for s in self._scopes]
+
+    def precedence(self, mode: str) -> Tuple[str, ...]:
+        """Return the read precedence order for *mode*.
+
+        ``mode`` must be one of ``"user_over_project"`` or
+        ``"project_over_user"``.
+        """
+
+        if mode == "user_over_project":
+            return PRECEDENCE_USER_WINS
+        if mode == "project_over_user":
+            return PRECEDENCE_PROJECT_WINS
+        raise ValueError(f"Unknown precedence mode: {mode}")
+
+    def allows(self, scope: str) -> bool:
+        """Return ``True`` if *scope* is writable."""
+        info = self._by_name.get(scope)
+        if info is None:
+            raise UnknownScopeError(scope)
+        return info.writable
+
+    def path(self, scope: str, provider_id: str, *, auto: bool = False) -> Path:
+        """Return configuration path for *scope* and *provider_id*.
+
+        This delegates to :func:`pysigil.config.target_path` and enforces
+        the write policy for scopes.
+        """
+
+        if not self.allows(scope):
+            raise SigilWriteError(f"Scope '{scope}' is read-only")
+        from . import config
+
+        return config.target_path(provider_id, scope, auto=auto)
+
+
+# Known scopes ordered from lowest to highest precedence
+_DEFAULT_SCOPES = [
+    Scope("core", writable=False),
+    Scope("default", writable=False),
+    Scope("project", writable=True),
+    Scope("project-local", writable=True),
+    Scope("user", writable=True),
+    Scope("user-local", writable=True),
+    Scope("env", writable=False),
+]
+
+policy = ScopePolicy(_DEFAULT_SCOPES)
+
+__all__ = [
+    "Scope",
+    "ScopePolicy",
+    "policy",
+    "CORE_DEFAULTS",
+    "PRECEDENCE_USER_WINS",
+    "PRECEDENCE_PROJECT_WINS",
+]

--- a/src/pysigil/settings_metadata.py
+++ b/src/pysigil/settings_metadata.py
@@ -42,7 +42,7 @@ from .errors import (
     UnknownProviderError,
 )
 from .io_config import IniIOError, read_sections, write_sections
-from .merge_policy import PRECEDENCE_PROJECT_WINS
+from .policy import policy
 from .paths import user_config_dir
 from .resolver import resolve_defaults
 from .root import ProjectRootNotFoundError, find_project_root
@@ -609,7 +609,7 @@ class IniFileBackend:
 
     def _iter_read_paths(self, provider_id: str) -> Iterable[tuple[str, Path]]:
         dl = get_dev_link(provider_id)
-        for scope in reversed(PRECEDENCE_PROJECT_WINS):
+        for scope in reversed(policy.precedence("project_over_user")):
             if scope in {"env", "core"}:
                 continue
             if scope == "default":


### PR DESCRIPTION
## Summary
- add `Scope` dataclass and `ScopePolicy` manager with default instance
- move core defaults and precedence constants into new policy module
- use centralized policy for precedence and path resolution across configuration, core, metadata and API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37027ce608328a7e8f10447514a09