### PR TITLE
Refactor configuration path handling to use policy

### DIFF
--- a/src/pysigil/core.py
+++ b/src/pysigil/core.py
@@ -295,7 +295,7 @@ class Sigil:
                 return self._cast(val, cast)
         full_path = (self.app_name, *raw_path)
         with self._lock:
-            order = self.policy.precedence("project_over_user")
+            order = self.policy.precedence(read=True)
             for scope in order:
                 val = self._value_from_scope(scope, full_path)
                 if val is not None:
@@ -401,7 +401,7 @@ class Sigil:
 
     def effective_scope_for(self, key: str | KeyPath) -> str:
         kp = parse_key(key)
-        order = self.policy.precedence("project_over_user")
+        order = self.policy.precedence(read=True)
         with self._lock:
             for scope in order:
                 if self._value_from_scope(scope, kp) is not None:

--- a/src/pysigil/policy.py
+++ b/src/pysigil/policy.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Tuple, MutableMapping, Iterator
+from typing import Iterable, Iterator, List, MutableMapping, Tuple
 
-from .errors import UnknownScopeError, SigilWriteError
+from .errors import SigilWriteError, UnknownScopeError
+from .root import ProjectRootNotFoundError
 
 # Predefined defaults for the core scope
 CORE_DEFAULTS = {"pysigil": {"policy": "project_over_user"}}
@@ -36,6 +37,7 @@ class Scope:
 
     name: str
     writable: bool = False
+    machine: bool = False
 
 
 class ScopePolicy:
@@ -45,24 +47,35 @@ class ScopePolicy:
         self._scopes: List[Scope] = list(scopes)
         self._by_name = {s.name: s for s in self._scopes}
         self._stores: dict[str, MutableMapping] = {}
+        self._machine = {s.name for s in self._scopes if s.machine}
 
     @property
     def scopes(self) -> List[str]:
         """Ordered list of known scope names."""
         return [s.name for s in self._scopes]
 
-    def precedence(self, mode: str) -> Tuple[str, ...]:
-        """Return the read precedence order for *mode*.
+    def precedence(self, *, read: bool = False) -> Tuple[str, ...]:
+        """Return the precedence order.
 
-        ``mode`` must be one of ``"user_over_project"`` or
-        ``"project_over_user"``.
+        When ``read`` is ``True`` the current policy is looked up from the
+        stored configuration.  If no policy is configured the project-over-user
+        order is assumed.
         """
 
-        if mode == "user_over_project":
-            return PRECEDENCE_USER_WINS
-        if mode == "project_over_user":
+        if not read:
             return PRECEDENCE_PROJECT_WINS
-        raise ValueError(f"Unknown precedence mode: {mode}")
+
+        key = ("pysigil", "policy")
+        for scope in PRECEDENCE_PROJECT_WINS:
+            store = self._stores.get(scope)
+            if store is None:
+                continue
+            mode = store.get(key)
+            if mode == "user_over_project":
+                return PRECEDENCE_USER_WINS
+            if mode == "project_over_user":
+                return PRECEDENCE_PROJECT_WINS
+        return PRECEDENCE_PROJECT_WINS
 
     def allows(self, scope: str) -> bool:
         """Return ``True`` if *scope* is writable."""
@@ -106,18 +119,36 @@ class ScopePolicy:
         for s in self._scopes:
             yield s.name
 
+    def machine_scopes(self) -> List[str]:
+        """Return scopes that are machine-specific."""
+
+        return list(self._machine)
+
     def path(self, scope: str, provider_id: str, *, auto: bool = False) -> Path:
         """Return configuration path for *scope* and *provider_id*.
 
-        This delegates to :func:`pysigil.config.target_path` and enforces
-        the write policy for scopes.
+        Directories are created as needed and writes are only permitted for
+        scopes marked writable in the policy.
         """
 
         if not self.allows(scope):
             raise SigilWriteError(f"Scope '{scope}' is read-only")
-        from . import config
 
-        return config.target_path(provider_id, scope, auto=auto)
+        from . import config
+        from .authoring import normalize_provider_id
+
+        pid = normalize_provider_id(provider_id)
+        if scope in {"user", "user-local"}:
+            base = Path(config.user_config_dir("sigil")) / pid
+        else:
+            root = config._project_dir(auto)
+            if root is None:
+                raise ProjectRootNotFoundError("No project root found")
+            base = root / ".sigil"
+        base.mkdir(parents=True, exist_ok=True)
+        if scope in self._machine or pid == "user-custom":
+            return base / f"settings-local-{config.host_id()}.ini"
+        return base / "settings.ini"
 
 
 # Known scopes ordered from lowest to highest precedence
@@ -125,9 +156,9 @@ _DEFAULT_SCOPES = [
     Scope("core", writable=False),
     Scope("default", writable=False),
     Scope("project", writable=True),
-    Scope("project-local", writable=True),
+    Scope("project-local", writable=True, machine=True),
     Scope("user", writable=True),
-    Scope("user-local", writable=True),
+    Scope("user-local", writable=True, machine=True),
     Scope("env", writable=False),
 ]
 

--- a/src/pysigil/settings_metadata.py
+++ b/src/pysigil/settings_metadata.py
@@ -609,7 +609,7 @@ class IniFileBackend:
 
     def _iter_read_paths(self, provider_id: str) -> Iterable[tuple[str, Path]]:
         dl = get_dev_link(provider_id)
-        for scope in reversed(policy.precedence("project_over_user")):
+        for scope in reversed(policy.precedence(read=True)):
             if scope in {"env", "core"}:
                 continue
             if scope == "default":


### PR DESCRIPTION
## Summary
- centralize scope precedence logic with policy.precedence(read=True)
- delegate config path resolution to policy.path and policy.machine_scopes
- adjust core and settings metadata to use new precedence API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b37571ee34832894ae5ddf3b6d9cf6