### PR TITLE
Inject policy into IniFileBackend

### DIFF
--- a/src/pysigil/orchestrator.py
+++ b/src/pysigil/orchestrator.py
@@ -49,17 +49,11 @@ class Orchestrator:
         self,
         spec_backend: SpecBackend | None = None,
         config_backend: SigilBackend | None = None,
-        *,
-        user_dir: Path | None = None,
-        project_dir: Path | None = None,
-        host: str | None = None,
     ) -> None:
         if spec_backend is None:
             spec_backend = IniSpecBackend()
         if config_backend is None:
-            config_backend = IniFileBackend(
-                user_dir=user_dir, project_dir=project_dir, host=host
-            )
+            config_backend = IniFileBackend()
         self.spec_backend = spec_backend
         self.config_backend = config_backend
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,11 +3,13 @@ import pytest
 from pysigil import api
 from pysigil.orchestrator import Orchestrator
 from pysigil.settings_metadata import IniFileBackend, IniSpecBackend
+from tests.utils import DummyPolicy
 
 
 def make_api(tmp_path):
     spec = IniSpecBackend(user_dir=tmp_path / "meta")
-    cfg = IniFileBackend(user_dir=tmp_path / "user", project_dir=tmp_path / "proj")
+    policy = DummyPolicy(tmp_path / "user", tmp_path / "proj", host="host")
+    cfg = IniFileBackend(policy=policy)
     orch = Orchestrator(spec_backend=spec, config_backend=cfg)
     api._ORCH = orch  # type: ignore[attr-defined]
     return api

--- a/tests/test_settings_metadata.py
+++ b/tests/test_settings_metadata.py
@@ -9,6 +9,7 @@ from pysigil.settings_metadata import (
     ProviderSpec,
 )
 from pysigil.io_config import read_sections, write_sections
+from tests.utils import DummyPolicy
 
 
 def test_fieldspec_validates_unknown_type():
@@ -64,7 +65,8 @@ def test_provider_manager_roundtrip():
 def test_ini_file_backend(tmp_path):
     user_dir = tmp_path / "user"
     project_dir = tmp_path / "proj"
-    backend = IniFileBackend(user_dir=user_dir, project_dir=project_dir, host="host")
+    policy = DummyPolicy(user_dir, project_dir, host="host")
+    backend = IniFileBackend(policy=policy)
 
     write_sections(user_dir / "demo" / "settings.ini", {"demo": {"alpha": "u"}})
     write_sections(project_dir / "settings.ini", {"demo": {"alpha": "p", "beta": "p"}})
@@ -73,7 +75,6 @@ def test_ini_file_backend(tmp_path):
     )
 
     raw, src = backend.read_merged("demo")
-    print(raw)
     assert raw == {"alpha": "p", "beta": "pl"}
     assert src == {"alpha": "project", "beta": "project-local"}
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pysigil.root import ProjectRootNotFoundError
+
+
+class DummyPolicy:
+    """Simple scope policy used in tests.
+
+    The policy mirrors the old behaviour of :class:`IniFileBackend` by storing
+    user configuration under ``user_dir/<provider>`` and project configuration
+    directly under ``project_dir``.
+    """
+
+    def __init__(self, user_dir: Path, project_dir: Path | None, host: str = "host"):
+        self.user_dir = Path(user_dir)
+        self.project_dir = Path(project_dir) if project_dir is not None else None
+        self.host = host
+
+    def precedence(self, *, read: bool = False):
+        return (
+            "env",
+            "project-local",
+            "project",
+            "user-local",
+            "user",
+            "default",
+            "core",
+        )
+
+    def path(self, scope: str, provider_id: str, *, auto: bool = False) -> Path:
+        pid = provider_id
+        if scope == "user":
+            base = self.user_dir / pid
+            base.mkdir(parents=True, exist_ok=True)
+            name = (
+                f"settings-local-{self.host}.ini" if pid == "user-custom" else "settings.ini"
+            )
+            return base / name
+        if scope == "user-local":
+            base = self.user_dir / pid
+            base.mkdir(parents=True, exist_ok=True)
+            return base / f"settings-local-{self.host}.ini"
+        if scope == "project":
+            if self.project_dir is None:
+                raise ProjectRootNotFoundError("No project directory configured")
+            base = self.project_dir
+            base.mkdir(parents=True, exist_ok=True)
+            return base / "settings.ini"
+        if scope == "project-local":
+            if self.project_dir is None:
+                raise ProjectRootNotFoundError("No project directory configured")
+            base = self.project_dir
+            base.mkdir(parents=True, exist_ok=True)
+            return base / f"settings-local-{self.host}.ini"
+        raise ValueError(f"unknown scope {scope!r}")
+
+    def allows(self, scope: str) -> bool:  # pragma: no cover - trivial
+        return scope in {"user", "user-local", "project", "project-local", "default"}
+
+    def machine_scopes(self):  # pragma: no cover - trivial
+        return ["user-local", "project-local"]


### PR DESCRIPTION
## Summary
- inject ScopePolicy into IniFileBackend and use policy.path()/precedence()
- simplify Orchestrator setup and allow any registered scope transactions
- update tests with a DummyPolicy for path handling

## Testing
- `pre-commit run --files src/pysigil/settings_metadata.py src/pysigil/orchestrator.py tests/utils.py tests/test_settings_metadata.py tests/test_api.py tests/test_orchestrator.py` *(command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b378625aa08328a116024e65d7c8be