### PR TITLE
Add policy interface docs and tests

### DIFF
--- a/AUTHORS_GUIDE.md
+++ b/AUTHORS_GUIDE.md
@@ -94,6 +94,23 @@ Each link file is a tiny INI like:
 defaults=/abs/path/to/my_pkg/.sigil/settings.ini
 ```
 
+## Policy API
+
+Advanced authors may extend the configuration policy.  Scopes describe
+where settings live and whether they are writable or bound to a machine.
+
+```python
+from pysigil.policy import Scope, ScopePolicy, policy
+
+# add a scope committed to git
+scopes = [*policy._scopes, Scope("git", writable=True)]
+git_policy = ScopePolicy(scopes)
+
+# add a machine specific scope
+scopes = [*policy._scopes, Scope("ci", writable=True, machine=True)]
+ci_policy = ScopePolicy(scopes)
+```
+
 ## Packaging tip
 
 When you publish, include `.sigil/settings.ini` in your wheel:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ Typed helper methods are available for convenient access:
 `Sigil.get_int()`, `get_float()`, `get_bool()`.
 For package integration details see [docs/integration.md](docs/integration.md).
 
+## Policy API
+
+The merge order and write permissions are managed by a configurable
+`ScopePolicy`.  The default policy prefers project settings over user ones.
+To inspect or extend the policy:
+
+```python
+from pysigil.policy import Scope, ScopePolicy, policy
+
+# clone and add a git-tracked scope
+scopes = [*policy._scopes, Scope("git", writable=True)]
+git_policy = ScopePolicy(scopes)
+
+# precedence can be switched at runtime
+policy.set_store("user", {("pysigil", "policy"): "user_over_project"})
+```
+
 ## Using the GUI
 
 pysigil ships with a simple graphical editor for viewing and editing

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -39,3 +39,20 @@ Files auto-created as needed.
 Zero runtime deps: pysigil is pure std-lib + your INI file.
 
 That’s it. Add one defaults file, one `[tool.sigil]` line, (optionally) four helper lines — and your package instantly gains a robust, chain-aware configuration system.
+
+## Custom scopes
+
+If the defaults are not enough you can extend the policy.  A *git-only* scope
+keeps settings under version control while a *machine* scope stores
+host-specific files.
+
+```python
+from pysigil.policy import Scope, ScopePolicy, policy
+
+git_only = Scope("git", writable=True)
+machine = Scope("ci", writable=True, machine=True)
+custom = ScopePolicy([*policy._scopes, git_only, machine])
+```
+
+The `machine=True` flag causes the file name to include the host, e.g.
+`settings-local-myhost.ini`.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,14 @@ def test_precedence(monkeypatch, tmp_path: Path) -> None:
     data = cfg.load("pkg")
     assert data == {"a": "4"}
 
+    # switch precedence to user-over-project
+    cfg.policy.set_store("user", {("pysigil", "policy"): "user_over_project"})
+    try:
+        data = cfg.load("pkg")
+        assert data == {"a": "2"}
+    finally:
+        cfg.policy._stores.clear()
+
 
 def test_invalid_ini_logs_warning(monkeypatch, tmp_path: Path, caplog) -> None:
     user_dir, _ = _patch_env(monkeypatch, tmp_path)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from pysigil.policy import (
+    PRECEDENCE_PROJECT_WINS,
+    PRECEDENCE_USER_WINS,
+    SigilWriteError,
+    policy as default_policy,
+)
+
+
+def test_precedence_modes() -> None:
+    p = default_policy.clone()
+    assert p.precedence(read=True) == PRECEDENCE_PROJECT_WINS
+
+    store = {("pysigil", "policy"): "user_over_project"}
+    p.set_store("user", store)
+    assert p.precedence(read=True) == PRECEDENCE_USER_WINS
+    assert p.precedence(read=False) == PRECEDENCE_PROJECT_WINS
+
+
+def test_write_rules(tmp_path, monkeypatch) -> None:
+    from pysigil import config as cfg
+
+    monkeypatch.setattr(cfg, "user_config_dir", lambda app: str(tmp_path))
+    monkeypatch.setattr(cfg, "_project_dir", lambda auto: tmp_path)
+
+    p = default_policy.clone()
+
+    path = p.path("user", "mypkg")
+    assert path == tmp_path / "mypkg" / "settings.ini"
+
+    with pytest.raises(SigilWriteError):
+        p.path("env", "mypkg")


### PR DESCRIPTION
## Summary
- document ScopePolicy usage in README and author guide
- add examples for git-only and machine scopes
- add ScopePolicy tests for precedence and write permissions
- extend config tests for user-over-project precedence

## Testing
- `pytest`
- `pre-commit run --files AUTHORS_GUIDE.md README.md docs/integration.md tests/test_config.py tests/test_policy.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b37bab277c8328b0e129520b83383d