### PR TITLE
feat: add Tk field row with scope pills

### DIFF
--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, Any
+
+try:  # pragma: no cover - tkinter may be missing
+    import tkinter as tk
+    from tkinter import ttk
+except Exception:  # pragma: no cover
+    tk = None  # type: ignore
+    ttk = None  # type: ignore
+
+from ..provider_adapter import ProviderAdapter, ValueInfo
+from .widgets import PillButton, SCOPE_COLOR, GREY_BG
+
+# Mapping from scope ids to color constants used by :class:`PillButton`
+_SCOPE_COLORS = {
+    "env": SCOPE_COLOR["Env"],
+    "user": SCOPE_COLOR["User"],
+    "user-local": SCOPE_COLOR["Machine"],
+    "project": SCOPE_COLOR["Project"],
+    "project-local": SCOPE_COLOR["ProjectMachine"],
+    "default": SCOPE_COLOR["Def"],
+}
+
+
+class FieldRow(ttk.Frame):
+    """Representation of a single field row with scope pills."""
+
+    def __init__(
+        self,
+        master: tk.Widget,
+        adapter: ProviderAdapter,
+        key: str,
+        on_pill_click: Callable[[str, str], None],
+        *,
+        compact: bool = True,
+    ) -> None:
+        super().__init__(master)
+        self.adapter = adapter
+        self.key = key
+        self._on_pill_click = on_pill_click
+        self.compact = compact
+
+        # key label
+        self.lbl_key = ttk.Label(self, text=key)
+        self.lbl_key.grid(row=0, column=0, sticky="w")
+
+        # effective value display
+        self.var_eff = tk.StringVar(value="") if tk else None
+        self.lbl_eff = tk.Label(
+            self,
+            textvariable=self.var_eff,
+            bg=GREY_BG,
+            fg="#111111",
+            bd=1,
+            relief="ridge",
+            padx=10,
+            pady=6,
+        )
+        self.lbl_eff.grid(row=0, column=1, sticky="ew", padx=(8, 8))
+
+        # container for scope pills
+        self.pills = ttk.Frame(self)
+        self.pills.grid(row=0, column=2, sticky="w")
+
+        self.columnconfigure(1, weight=1)
+
+        self.refresh()
+
+    # ------------------------------------------------------------------
+    def set_compact(self, compact: bool) -> None:
+        """Toggle compact mode and rebuild pills."""
+        if self.compact != compact:
+            self.compact = compact
+            self.refresh()
+
+    # ------------------------------------------------------------------
+    def refresh(self) -> None:
+        """Refresh the effective value and rebuild scope pills."""
+        if tk is None:  # pragma: no cover - defensive
+            return
+
+        # locked effective value -------------------------------------------------
+        eff_val, eff_src = self.adapter.effective_for_key(self.key)
+        val_txt = "—" if eff_val is None else str(eff_val)
+        if eff_src is None:
+            src_txt = "—"
+        else:
+            src_txt = self.adapter.scope_label(eff_src)
+        lock = "\U0001F512 "
+        self.var_eff.set(f"{lock}{val_txt}  ({src_txt})")
+
+        # rebuild pills ----------------------------------------------------------
+        for child in list(self.pills.winfo_children()):
+            child.destroy()
+
+        values: Dict[str, ValueInfo] = self.adapter.values_for_key(self.key)
+        scopes = self.adapter.scopes()
+        for scope in scopes:
+            has_value = scope in values
+            if self.compact and scope != "default" and not has_value:
+                continue
+
+            if not self.adapter.can_write(scope):
+                state = "disabled"
+            elif eff_src == scope:
+                state = "effective"
+            elif has_value:
+                state = "present"
+            else:
+                state = "empty"
+
+            short_label = self.adapter.scope_label(scope, short=True)
+            long_label = self.adapter.scope_label(scope, short=False)
+            color = _SCOPE_COLORS.get(scope, "#888888")
+
+            def value_provider(s=scope) -> Any:
+                if s in values:
+                    return values[s].value
+                if s == "default":
+                    return self.adapter.default_for_key(self.key)
+                return None
+
+            def cb(s=scope, st=state) -> None:
+                if st != "disabled" and self._on_pill_click:
+                    self._on_pill_click(self.key, s)
+
+            pill = PillButton(
+                self.pills,
+                text=short_label,
+                color=color,
+                state=state,  # type: ignore[arg-type]
+                value_provider=value_provider,
+                clickable=state != "disabled",
+                on_click=cb,
+                tooltip_title=long_label,
+            )
+            pill.pack(side="left", padx=(0, 6))
+
+
+__all__ = ["FieldRow"]

--- a/tests/test_field_row.py
+++ b/tests/test_field_row.py
@@ -1,0 +1,97 @@
+import pytest
+
+try:
+    import tkinter as tk
+except Exception:  # pragma: no cover - tkinter missing
+    tk = None  # type: ignore
+
+from pysigil.ui.tk.rows import FieldRow
+from pysigil.ui.tk.widgets import PillButton
+from pysigil.ui.provider_adapter import ValueInfo
+
+
+class DummyAdapter:
+    def scopes(self):
+        return ["env", "user", "user-local", "project", "project-local", "default"]
+
+    def scope_label(self, scope_id, short=False):
+        short_labels = {
+            "env": "Env",
+            "user": "User",
+            "user-local": "Machine",
+            "project": "Project",
+            "project-local": "Project·Machine",
+            "default": "Default",
+        }
+        long_labels = {
+            "env": "Environment",
+            "user": "User",
+            "user-local": "Machine",
+            "project": "Project",
+            "project-local": "Project on this Machine",
+            "default": "Default",
+        }
+        return (short_labels if short else long_labels)[scope_id]
+
+    def can_write(self, scope_id):
+        return scope_id not in {"env", "project"}
+
+    def values_for_key(self, key):
+        return {
+            "env": ValueInfo("e"),
+            "user": ValueInfo("u"),
+            "project-local": ValueInfo("pl"),
+            "default": ValueInfo("d"),
+        }
+
+    def effective_for_key(self, key):
+        return "u", "user"
+
+    def default_for_key(self, key):
+        return "d"
+
+
+def _collect_pills(row):
+    return [w for w in row.pills.winfo_children() if isinstance(w, PillButton)]
+
+
+def test_field_row_full_mode(monkeypatch):
+    if tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+    clicks = []
+    row = FieldRow(root, DummyAdapter(), "alpha", lambda k, s: clicks.append((k, s)), compact=False)
+    states = {p.text: p.state for p in _collect_pills(row)}
+    assert states == {
+        "Env": "disabled",
+        "User": "effective",
+        "Machine": "empty",
+        "Project": "disabled",
+        "Project·Machine": "present",
+        "Default": "present",
+    }
+    for p in _collect_pills(row):
+        if p.text == "User":
+            p.on_click()
+            break
+    assert clicks == [("alpha", "user")]
+    lock_txt = row.var_eff.get()
+    assert lock_txt.startswith("\U0001F512 u")
+    assert "(User)" in lock_txt
+    root.destroy()
+
+
+def test_field_row_compact_mode():
+    if tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+    row = FieldRow(root, DummyAdapter(), "alpha", lambda k, s: None, compact=True)
+    pills = _collect_pills(row)
+    assert [p.text for p in pills] == ["Env", "User", "Project·Machine", "Default"]
+    root.destroy()


### PR DESCRIPTION
## Summary
- implement FieldRow widget for Tk with scope pills driven by ProviderAdapter
- support compact/full scope modes and pill click callbacks
- add tests covering pill states and compact mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b38179248c8328960d3ea1920dda18