### PR TITLE
Validate normalized names and reject path segments

### DIFF
--- a/src/pysigil/authoring.py
+++ b/src/pysigil/authoring.py
@@ -29,11 +29,26 @@ class DevLink:
 
 
 _PEP503_RE = re.compile(r"[-_.]+")
+_VALID_RE = re.compile(r"^[a-z0-9-]+$")
 
 
 def normalize_provider_id(name: str) -> str:
-    """PEP 503 normalize ``name``."""
-    return _PEP503_RE.sub("-", name).lower()
+    """PEP 503 normalize ``name``.
+
+    ``name`` is normalised to lowercase with hyphens and must not contain path
+    separators or ``..`` segments.
+    """
+
+    stripped = name.strip().lower()
+    norm = _PEP503_RE.sub("-", stripped)
+    if (
+        "/" in stripped
+        or "\\" in stripped
+        or ".." in stripped
+        or not _VALID_RE.fullmatch(norm)
+    ):
+        raise ValueError(f"invalid provider id: {name!r}")
+    return norm
 
 
 def _dev_dir() -> Path:

--- a/src/pysigil/core.py
+++ b/src/pysigil/core.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from threading import RLock
 from typing import Any
 
+from .authoring import normalize_provider_id
 from .discovery import pep503_name
 from .errors import (
     ReadOnlyScopeError,
@@ -62,7 +63,11 @@ class Sigil:
         # treated equivalently across all scopes.  This mirrors the
         # normalisation used for provider discovery (PEP 503) and ensures that
         # configuration files using either convention are correctly recognised.
-        self.app_name = pep503_name(app_name)
+        try:
+            normalize_provider_id(app_name)
+            self.app_name = pep503_name(app_name)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"invalid application name: {app_name!r}") from exc
         self.settings_filename = settings_filename
 
         self._host = host_id()

--- a/src/pysigil/discovery.py
+++ b/src/pysigil/discovery.py
@@ -7,11 +7,26 @@ from importlib.metadata import Distribution, entry_points
 GROUPS = ("pysigil_providers", "pysigil.providers")
 
 _RE = re.compile(r"[-_.]+")
+_VALID_RE = re.compile(r"^[a-z0-9-]+$")
 
 
 def pep503_name(dist_name: str) -> str:
-    """Return the PEP 503 normalised project name."""
-    return _RE.sub("-", dist_name.strip().lower())
+    """Return the PEP 503 normalised project name.
+
+    ``dist_name`` must normalise to only contain lowercase letters, digits and
+    hyphens.  Names containing path separators or ``..`` are rejected.
+    """
+
+    stripped = dist_name.strip()
+    name = _RE.sub("-", stripped.lower())
+    if (
+        "/" in stripped
+        or "\\" in stripped
+        or ".." in stripped
+        or not _VALID_RE.fullmatch(name)
+    ):
+        raise ValueError(f"invalid project name: {dist_name!r}")
+    return name
 
 
 def _iter_entry_points():

--- a/tests/test_invalid_names.py
+++ b/tests/test_invalid_names.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pysigil import Sigil
+from pysigil.authoring import normalize_provider_id
+from pysigil.discovery import pep503_name
+from pysigil.policy import policy
+
+
+@pytest.mark.parametrize("name", ["foo/bar", "foo\\bar", "foo..bar"])
+def test_pep503_name_rejects_invalid(name):
+    with pytest.raises(ValueError):
+        pep503_name(name)
+
+
+@pytest.mark.parametrize("name", ["foo/bar", "foo\\bar", "foo..bar"])
+def test_normalize_provider_id_rejects_invalid(name):
+    with pytest.raises(ValueError):
+        normalize_provider_id(name)
+
+
+@pytest.mark.parametrize("name", ["foo/bar", "foo\\bar", "foo..bar"])
+def test_sigil_rejects_invalid_app_name(name, tmp_path):
+    with pytest.raises(ValueError):
+        Sigil(name, user_scope=tmp_path / "user.ini", policy=policy)


### PR DESCRIPTION
## Summary
- validate normalized project and provider names against `[a-z0-9-]+`
- fail `Sigil` initialization when app name contains path separators or `..`
- add tests confirming `/`, `\` and `..` are rejected

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/authoring.py src/pysigil/core.py src/pysigil/discovery.py tests/test_invalid_names.py` *(fails: command not found and pip install pre-commit 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b381acf1cc83288da5487f9f2b0304