### PR TITLE
Replace Tk view with simple provider App

### DIFF
--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -1,328 +1,194 @@
-"""Tkinter based view layer for :mod:`pysigil.ui`.
+"""Tk based view helpers for :mod:`pysigil`.
 
-The classes in this module provide a very small concrete implementation of
-:class:`pysigil.ui.core.AppCore` using tkinter.  The goal of the module is
-not to offer a feature complete GUI but rather to demonstrate how a view
-layer can be wired to the framework agnostic core.
+This module exposes a tiny :class:`App` class that wires
+the :class:`~pysigil.ui.provider_adapter.ProviderAdapter` with a
+minimal tkinter user interface.  It is intentionally small and aims to
+offer just enough features for manual exploration and for unit tests
+exercising the view layer.  The implementation favours simplicity so it
+can later be adapted for other widget toolkits.  To make this possible a
+lightweight :class:`~pysigil.ui.core.EventBus` instance is used which can
+be shared with other UI layers in the future.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Literal, Protocol
+from typing import Dict
 
-try:  # pragma: no cover - importing tkinter is environment dependent
+try:  # pragma: no cover - tkinter availability depends on the env
     import tkinter as tk
-    from tkinter import messagebox, simpledialog, ttk
+    from tkinter import ttk
 except Exception:  # pragma: no cover - fallback when tkinter missing
     tk = None  # type: ignore
-    messagebox = None  # type: ignore
-    simpledialog = None  # type: ignore
     ttk = None  # type: ignore
 
-
-from ... import api
-from ..core import AppCore, AppState
-from ..widgets import FIELD_WIDGETS
-
-
-class ViewAdapter(Protocol):
-    """Minimal protocol expected by :class:`AppCore` front-ends."""
-
-    def bind_state(self, callback: Callable[[AppState], None]) -> None: ...
-    def show_toast(self, msg: str, level: Literal["info", "warn", "error"]) -> None: ...
-    def confirm(self, title: str, msg: str) -> bool: ...
-    def prompt_new_field(self): ...
+from ..provider_adapter import ProviderAdapter
+from ..core import EventBus
+from .rows import FieldRow
+from .dialogs import EditDialog
 
 
-class FieldRow:
-    """Representation of a single editable field row."""
+class App:
+    """Very small tkinter application shell.
+
+    The class is primarily intended for tests and manual smoke checks.  It
+    showcases how :class:`ProviderAdapter` can be bound to a view layer and
+    how individual field rows are refreshed when values change.
+    """
 
     def __init__(
         self,
-        master: tk.Widget,
-        field: api.FieldInfo,
-        core: AppCore,
-        scope_var: tk.StringVar,
+        master: tk.Misc | None = None,
+        *,
+        adapter: ProviderAdapter | None = None,
+        events: EventBus | None = None,
     ) -> None:
-        self.key = field.key
-        self.core = core
-        self._scope_var = scope_var
-        self.frame = ttk.Frame(master)
-        self.frame.pack(fill="x", padx=5, pady=2)
-        self._label = ttk.Label(self.frame, text=field.label or field.key, anchor="w", width=20)
-        self._label.pack(side="left")
-        factory = FIELD_WIDGETS.get(field.type, FIELD_WIDGETS["string"])
-        self.editor = factory(self.frame)
-        self.editor.pack(side="left", fill="x", expand=True, padx=5)
-        ttk.Button(
-            self.frame,
-            text="Save",
-            command=self.on_save,
-        ).pack(side="left", padx=2)
-        ttk.Button(
-            self.frame,
-            text="Clear",
-            command=self.on_clear,
-        ).pack(side="left", padx=2)
+        if tk is None:  # pragma: no cover - environment without tkinter
+            raise RuntimeError("tkinter is required for App")
 
-    def update_label(self, text: str) -> None:
-        self._label.configure(text=text)
+        self.root = master if master is not None else tk.Tk()
+        self.adapter = adapter or ProviderAdapter()
+        self.events = events or EventBus()
+        self.compact = True
+        self.rows: Dict[str, FieldRow] = {}
+        self._edit_buttons: Dict[str, ttk.Button] = {}
 
-    def set_from_valueinfo(self, v: api.ValueInfo | None) -> None:
-        if v is None:
-            self.editor.set_value(None)
-            self.editor.set_source_badge(None)
-        else:
-            self.editor.set_value(v.value)
-            self.editor.set_source_badge(v.source)
-
-    def on_save(self) -> None:
-        self.core.save_value(
-            self.key, self.editor.get_value(), scope=self._scope_var.get()
-        )
-
-    def on_clear(self) -> None:
-        self.core.clear_value(self.key, scope=self._scope_var.get())
-
-    def focus(self) -> None:
-        try:
-            self.editor.focus_set()
-        except Exception:
-            children = getattr(self.editor, "winfo_children", lambda: [])()
-            if children:
-                try:
-                    children[0].focus_set()
-                except Exception:
-                    pass
-
-
-class TkApp:
-    """Very small tkinter application shell.
-
-    The application only exposes enough functionality for unit tests and
-    for developers experimenting with the new architecture.  A more
-    full-featured GUI can be built incrementally on top of this skeleton.
-    """
-
-    def __init__(self, core: AppCore | None = None) -> None:
-        if tk is None:  # pragma: no cover - tkinter not available
-            raise RuntimeError("tkinter is required for TkApp")
-        self.core = core or AppCore()
-        self.root = tk.Tk()
         self.root.title("pysigil")
-        self._state_cb: Callable[[AppState], None] | None = None
 
-        # provider selector and context header ----------------------------
+        self._build_header()
+        self._build_table()
+        self._populate_providers()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+    def _build_header(self) -> None:
         header = ttk.Frame(self.root)
-        header.pack(fill="x", padx=5, pady=5)
-        providers = self.core.service.list_providers()
+        header.pack(fill="x", padx=6, pady=6)
+
+        ttk.Label(header, text="Provider:").pack(side="left")
         self._provider_var = tk.StringVar()
         self._provider_box = ttk.Combobox(
             header, textvariable=self._provider_var, state="readonly"
         )
+        self._provider_box.pack(side="left", padx=(4, 12))
+        self._provider_box.bind("<<ComboboxSelected>>", self.on_provider_change)
+
+        self._compact_var = tk.BooleanVar(value=True)
+        ttk.Checkbutton(
+            header,
+            text="Compact",
+            variable=self._compact_var,
+            command=self.on_toggle_compact,
+        ).pack(side="left")
+
+    def _build_table(self) -> None:
+        self._table = ttk.Frame(self.root)
+        self._table.pack(fill="both", expand=True, padx=6, pady=6)
+
+        ttk.Label(self._table, text="Key").grid(row=0, column=0, sticky="w")
+        ttk.Label(self._table, text="Value (effective)").grid(
+            row=0, column=1, sticky="w"
+        )
+        ttk.Label(self._table, text="Scopes").grid(row=0, column=2, sticky="w")
+        ttk.Label(self._table, text="Edit…").grid(row=0, column=3, sticky="w")
+
+        self._table.columnconfigure(1, weight=1)
+
+    def _populate_providers(self) -> None:
+        providers = self.adapter.list_providers()
         self._provider_box["values"] = providers
-        self._provider_box.bind("<<ComboboxSelected>>", self._on_provider_selected)
-        self._provider_box.pack(side="left")
+        if providers:
+            self._provider_var.set(providers[0])
+            self.on_provider_change()
 
-        self._scope_var = tk.StringVar(value=self.core.state.active_scope)
-        ttk.Radiobutton(
-            header,
-            text="User",
-            variable=self._scope_var,
-            value="user",
-            command=self._on_scope_changed,
-        ).pack(side="left", padx=4)
-        ttk.Radiobutton(
-            header,
-            text="Project",
-            variable=self._scope_var,
-            value="project",
-            command=self._on_scope_changed,
-        ).pack(side="left", padx=4)
+    # ------------------------------------------------------------------
+    # Row handling
+    # ------------------------------------------------------------------
+    def _clear_rows(self) -> None:
+        for row in self.rows.values():
+            row.destroy()
+        for btn in self._edit_buttons.values():
+            btn.destroy()
+        self.rows.clear()
+        self._edit_buttons.clear()
 
-        self._host_label = ttk.Label(header, text=f"Host: {self.core.state.host_id}")
-        self._host_label.pack(side="left", padx=4)
-        self._proj_label = ttk.Label(header, text="No project detected")
-        self._proj_label.pack(side="left", padx=4)
+    def _rebuild_rows(self) -> None:
+        self._clear_rows()
+        for idx, key in enumerate(self.adapter.fields(), start=1):
+            row = FieldRow(
+                self._table,
+                self.adapter,
+                key,
+                self.on_pill_click,
+                compact=self.compact,
+            )
+            row.grid(row=idx, column=0, columnspan=3, sticky="ew", pady=2)
+            btn = ttk.Button(
+                self._table,
+                text="Edit…",
+                command=lambda k=key: self._open_edit_dialog(k),
+            )
+            btn.grid(row=idx, column=3, sticky="w", padx=4)
+            self.rows[key] = row
+            self._edit_buttons[key] = btn
 
-        btns = ttk.Frame(header)
-        btns.pack(side="right")
-        ttk.Button(
-            btns,
-            text="New setting",
-            command=self.prompt_new_field,
-        ).pack(side="left", padx=2)
-        ttk.Button(
-            btns,
-            text="Init",
-            command=lambda: self.core.init_scope(self._scope_var.get()),
-        ).pack(side="left", padx=2)
-        ttk.Button(
-            btns,
-            text="Open folder",
-            command=lambda: self.core.open_folder(self._scope_var.get()),
-        ).pack(side="left", padx=2)
-        ttk.Button(
-            btns,
-            text="Open file",
-            command=lambda: self.core.open_file(self._scope_var.get()),
-        ).pack(side="left", padx=2)
-        ttk.Button(
-            btns,
-            text="Add .gitignore",
-            command=self.core.add_gitignore,
-        ).pack(side="left", padx=2)
-
-        # container for field editors and read-only view -------------------
-        self._rows: dict[str, FieldRow] = {}
-        self._focus_key: str | None = None
-        self._notebook = ttk.Notebook(self.root)
-        self._fields_frame = ttk.Frame(self._notebook)
-        self._default_frame = ttk.Frame(self._notebook)
-        self._notebook.add(self._fields_frame, text="Settings")
-        self._notebook.add(self._default_frame, text="Default")
-        self._notebook.pack(fill="both", expand=True, padx=5, pady=5)
-        self._default_tree = ttk.Treeview(
-            self._default_frame,
-            columns=("key", "value", "source"),
-            show="headings",
+    def _open_edit_dialog(self, key: str, scope: str | None = None) -> None:
+        dlg = EditDialog(
+            self.root,
+            self.adapter,
+            key,
+            on_edit_save=self.on_edit_save,
+            on_edit_remove=self.on_edit_remove,
         )
-        for col in ("key", "value", "source"):
-            self._default_tree.heading(col, text=col.title())
-        self._default_tree.pack(fill="both", expand=True)
+        if scope:
+            entry = dlg.entries.get(scope)
+            if entry is not None:
+                try:  # pragma: no cover - focus issues are environment specific
+                    entry.focus_set()
+                except Exception:
+                    pass
 
-        # forward state changes to bound callback and local UI
-        self.core.events.on_state_changed.append(self._dispatch_state)
-        self.core.events.on_state_changed.append(self._on_state)
-        self.core.events.on_toast.append(self._on_toast)
-        self.core.events.on_error.append(lambda msg: self._on_toast(msg, "error"))
-
-        # keyboard shortcuts ----------------------------------------------
-        self.root.bind("/", lambda e: self._provider_box.focus_set())
-        self.root.bind("<F5>", lambda e: self.core.refresh())
-        self.root.bind("<Control-n>", lambda e: self.prompt_new_field())
-        self.root.bind("<Control-s>", lambda e: self.core.refresh())
-
-    # -- view adapter protocol ---------------------------------------
-    def bind_state(self, callback: Callable[[AppState], None]) -> None:
-        self._state_cb = callback
-
-    def show_toast(self, msg: str, level: Literal["info", "warn", "error"] = "info") -> None:
-        if messagebox is None:  # pragma: no cover - tkinter missing
-            return
-        if level == "error":
-            messagebox.showerror("pysigil", msg)
-        elif level == "warn":
-            messagebox.showwarning("pysigil", msg)
-        else:
-            messagebox.showinfo("pysigil", msg)
-
-    def confirm(self, title: str, msg: str) -> bool:
-        if messagebox is None:  # pragma: no cover
-            return False
-        return bool(messagebox.askyesno(title, msg))
-
-    def prompt_new_field(self):  # pragma: no cover - interactive dialog
-        if simpledialog is None or ttk is None:
-            return None
-
-        class _Dialog(simpledialog.Dialog):
-            def body(self, master):  # type: ignore[override]
-                ttk.Label(master, text="Key:").grid(row=0, column=0, sticky="w")
-                self.key = ttk.Entry(master)
-                self.key.grid(row=0, column=1, padx=4, pady=4)
-                ttk.Label(master, text="Type:").grid(row=1, column=0, sticky="w")
-                self.typ = ttk.Combobox(
-                    master, state="readonly", values=list(FIELD_WIDGETS.keys())
-                )
-                self.typ.grid(row=1, column=1, padx=4, pady=4)
-                ttk.Label(master, text="Label:").grid(row=2, column=0, sticky="w")
-                self.lab = ttk.Entry(master)
-                self.lab.grid(row=2, column=1, padx=4, pady=4)
-                ttk.Label(master, text="Description:").grid(row=3, column=0, sticky="w")
-                self.desc = ttk.Entry(master)
-                self.desc.grid(row=3, column=1, padx=4, pady=4)
-                return self.key
-
-            def apply(self):  # type: ignore[override]
-                self.result = {
-                    "key": self.key.get().strip(),
-                    "type": self.typ.get().strip() or "string",
-                    "label": self.lab.get().strip() or None,
-                    "description": self.desc.get().strip() or None,
-                }
-
-        dlg = _Dialog(self.root, "New setting")
-        data = dlg.result
-        if not data or not data.get("key"):
-            return None
-        self._focus_key = data["key"]
-        self.core.add_field(
-            data["key"],
-            data["type"],
-            label=data.get("label"),
-            description=data.get("description"),
-            init_scope=self._scope_var.get(),
-        )
-        return data
-
-    # -- internal helpers --------------------------------------------
-    def _dispatch_state(self, state: AppState) -> None:
-        if self._state_cb is not None:
-            self._state_cb(state)
-
-    # -- callbacks ---------------------------------------------------
-    def _on_provider_selected(self, _event=None) -> None:
+    # ------------------------------------------------------------------
+    # Callbacks
+    # ------------------------------------------------------------------
+    def on_provider_change(self, _event: object | None = None) -> None:
         pid = self._provider_var.get()
         if pid:
-            self.core.select_provider(pid)
+            try:
+                self.adapter.set_provider(pid)
+            except Exception as exc:  # pragma: no cover - defensive
+                self.events.emit_error(str(exc))
+                return
+            self._rebuild_rows()
 
-    def _on_state(self, state: AppState) -> None:
-        if ttk is None:  # pragma: no cover - tkinter missing
+    def on_pill_click(self, key: str, scope: str) -> None:
+        self._open_edit_dialog(key, scope)
+
+    def on_edit_save(self, key: str, scope: str, value: object) -> None:
+        try:
+            self.adapter.set_value(key, scope, value)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.events.emit_error(str(exc))
             return
-        self._scope_var.set(state.active_scope)
-        if state.project_root is not None:
-            self._proj_label.configure(text=str(state.project_root))
-        else:
-            self._proj_label.configure(text="No project detected")
-        self._host_label.configure(text=f"Host: {state.host_id}")
+        row = self.rows.get(key)
+        if row is not None:
+            row.refresh()
 
-        # --- sync rows -------------------------------------------------
-        current = set(self._rows.keys())
-        incoming = {f.key for f in state.fields}
-        for key in current - incoming:
-            self._rows[key].frame.destroy()
-            del self._rows[key]
-        for field in state.fields:
-            row = self._rows.get(field.key)
-            if row is None:
-                row = FieldRow(self._fields_frame, field, self.core, self._scope_var)
-                self._rows[field.key] = row
-            else:
-                row.update_label(field.label or field.key)
-        for field in state.fields:
-            val = state.values.get(field.key)
-            self._rows[field.key].set_from_valueinfo(val)
+    def on_edit_remove(self, key: str, scope: str) -> None:
+        try:
+            self.adapter.clear_value(key, scope)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.events.emit_error(str(exc))
+            return
+        row = self.rows.get(key)
+        if row is not None:
+            row.refresh()
 
-        # --- refresh default view -------------------------------------
-        tree = self._default_tree
-        tree.delete(*tree.get_children())
-        for field in state.fields:
-            val = state.values.get(field.key)
-            value = "" if val is None else str(val.value)
-            src = "" if val is None else (val.source or "")
-            tree.insert("", "end", iid=field.key, values=(field.key, value, src))
-
-        if self._focus_key and self._focus_key in self._rows:
-            self._rows[self._focus_key].focus()
-            self._focus_key = None
-
-    def _on_scope_changed(self) -> None:
-        self.core.set_active_scope(self._scope_var.get())
-
-    def _on_toast(self, msg: str, level: str) -> None:
-        self.show_toast(msg, level)
+    def on_toggle_compact(self) -> None:
+        self.compact = bool(self._compact_var.get())
+        for row in self.rows.values():
+            row.set_compact(self.compact)
 
 
-__all__ = ["TkApp", "ViewAdapter"]
+__all__ = ["App"]
+

--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -12,8 +12,6 @@ be shared with other UI layers in the future.
 
 from __future__ import annotations
 
-from typing import Dict
-
 try:  # pragma: no cover - tkinter availability depends on the env
     import tkinter as tk
     from tkinter import ttk
@@ -49,8 +47,8 @@ class App:
         self.adapter = adapter or ProviderAdapter()
         self.events = events or EventBus()
         self.compact = True
-        self.rows: Dict[str, FieldRow] = {}
-        self._edit_buttons: Dict[str, ttk.Button] = {}
+        self.rows: dict[str, FieldRow] = {}
+        self._edit_buttons: dict[str, ttk.Button] = {}
 
         self.root.title("pysigil")
 

--- a/tests/manual/manual_ui.py
+++ b/tests/manual/manual_ui.py
@@ -4,9 +4,9 @@ Run this module directly to open the GUI.  The interface will list all
 registered providers and allow selecting one to display its fields.
 """
 
-from pysigil.ui.tk import TkApp
+from pysigil.ui.tk import App
 
 if __name__ == "__main__":  # pragma: no cover - manual test only
-    app = TkApp()
+    app = App()
     app.root.mainloop()
 


### PR DESCRIPTION
## Summary
- Replace old TkApp implementation with smaller App class using ProviderAdapter
- Populate provider combo, render field rows with editable pills and headers
- Update manual UI harness for new App class

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3833a17d08328933e86ef8360e442