### PR TITLE
Add ProviderAdapter UI tests and document adapter boundary

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -22,3 +22,35 @@ Set the environment variable `SIGIL_GUI_DEBUG=1` before launching the GUI to
 emit verbose debug information to the console.  This can help diagnose problems
 with package loading or preference updates and can be disabled by unsetting the
 variable.
+
+## Adapter boundary and scope handling
+
+The GUI communicates with the core only through the
+[`ProviderAdapter`](../src/pysigil/ui/provider_adapter.py).  Widgets ask the
+adapter which scopes to render, obtain human‑readable labels, and read or write
+values.  This separation keeps toolkit code decoupled from `pysigil.api`.
+
+```python
+from pysigil.ui.provider_adapter import ProviderAdapter
+
+adapter = ProviderAdapter()
+adapter.set_provider("demo")
+for scope in adapter.scopes():
+    print(adapter.scope_label(scope, short=True), adapter.can_write(scope))
+```
+
+Toolkit components can mirror the prototype’s pill behaviour by wiring the
+adapter into callbacks:
+
+```python
+from pysigil.ui.tk.rows import FieldRow
+
+def on_pill_click(key: str, scope: str) -> None:
+    adapter.set_value(key, scope, "42")
+
+row = FieldRow(parent, adapter, "alpha", on_pill_click)
+```
+
+Each pill invokes `on_pill_click` with its scope, allowing dialogs or other
+widgets to focus edits to that layer while the adapter manages precedence and
+scope visibility.

--- a/tests/ui/test_provider_adapter.py
+++ b/tests/ui/test_provider_adapter.py
@@ -1,0 +1,77 @@
+import pytest
+
+try:
+    import tkinter as tk
+except Exception:  # pragma: no cover - tkinter missing
+    tk = None  # type: ignore
+
+from pysigil import api
+from pysigil.ui.provider_adapter import ProviderAdapter
+from pysigil.ui.tk.rows import FieldRow
+from pysigil.ui.tk.widgets import PillButton
+from pysigil.settings_metadata import IniFileBackend, IniSpecBackend
+from pysigil.orchestrator import Orchestrator
+from tests.utils import DummyPolicy
+
+
+def _setup_adapter(tmp_path, monkeypatch):
+    spec = IniSpecBackend(user_dir=tmp_path / "meta")
+    pol = DummyPolicy(tmp_path / "user", tmp_path / "proj")
+    cfg = IniFileBackend(policy=pol)
+    orch = Orchestrator(spec_backend=spec, config_backend=cfg)
+    monkeypatch.setattr(api, "_ORCH", orch, raising=False)
+    adapter = ProviderAdapter()
+    api.register_provider("demo", title="Demo")
+    handle = api.handle("demo")
+    handle.add_field("alpha", "integer")
+    adapter.set_provider("demo")
+    return adapter
+
+
+def test_adapter_writes_and_effective(tmp_path, monkeypatch):
+    adapter = _setup_adapter(tmp_path, monkeypatch)
+    assert adapter.list_providers() == ["demo"]
+    assert adapter.fields() == ["alpha"]
+
+    adapter.set_value("alpha", "user", 1)
+    eff_val, eff_scope = adapter.effective_for_key("alpha")
+    assert eff_val == 1
+    assert eff_scope == "user"
+
+    adapter.set_value("alpha", "project", 2)
+    eff_val, eff_scope = adapter.effective_for_key("alpha")
+    assert eff_val == 2
+    assert eff_scope == "project"
+
+    adapter.clear_value("alpha", "project")
+    eff_val, eff_scope = adapter.effective_for_key("alpha")
+    assert eff_val == 1
+    assert eff_scope == "user"
+
+
+def _collect_pills(row):
+    return [w for w in row.pills.winfo_children() if isinstance(w, PillButton)]
+
+
+def test_field_row_pill_click(tmp_path, monkeypatch):
+    if tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+
+    adapter = _setup_adapter(tmp_path, monkeypatch)
+    adapter.set_value("alpha", "user", 1)
+
+    clicks = []
+    row = FieldRow(root, adapter, "alpha", lambda k, s: clicks.append((k, s)), compact=False)
+    states = {p.text: p.state for p in _collect_pills(row)}
+    assert states["User"] == "effective"
+
+    for pill in _collect_pills(row):
+        if pill.text == "User":
+            pill.on_click()
+            break
+    assert clicks == [("alpha", "user")]
+    root.destroy()


### PR DESCRIPTION
## Summary
- add tests for ProviderAdapter and pill clicks
- document adapter boundary and scope handling with examples

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b385a68624832891be1d74e8c877b6