### PR TITLE
Switch sigil gui to new Tk UI with project path display

### DIFF
--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -26,7 +26,7 @@ from .config import (
 )
 from .core import Sigil
 from .discovery import pep503_name
-from .gui import launch_gui
+from .ui.tk import launch as launch_gui
 from .paths import (
     default_config_dir,
     default_data_dir,
@@ -193,11 +193,7 @@ def export_cmd(args: argparse.Namespace) -> int:
 
 
 def gui_cmd(args: argparse.Namespace) -> int:  # pragma: no cover - GUI interactions
-    launch_gui(
-        package=args.app,
-        include_sigil=args.include_sigil,
-        remember_state=not args.no_remember,
-    )
+    launch_gui(initial_provider=args.app)
     return 0
 
 

--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -98,6 +98,8 @@ class FieldRow(ttk.Frame):
         scopes = self.adapter.scopes()
         for scope in scopes:
             has_value = scope in values
+            if scope == "default" and not has_value:
+                continue
             if self.compact and scope != "default" and not has_value:
                 continue
 

--- a/src/pysigil/ui/tk/widgets.py
+++ b/src/pysigil/ui/tk/widgets.py
@@ -29,7 +29,7 @@ SCOPE_COLOR = {
     "Machine": "#065f46",  # emerald-900
     "Project": "#6d28d9",  # violet-700
     "ProjectMachine": "#c2410c",  # orange-700
-    "Def": "#334155",  # slate-700
+    "Def": "#000000",  # black
 }
 
 GREY_BG = "#f3f4f6"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,54 @@
+import pytest
+from pathlib import Path
+
+try:
+    import tkinter as tk
+except Exception:  # pragma: no cover - tkinter missing
+    tk = None  # type: ignore
+
+from pysigil.ui.tk import App
+
+
+class StubAdapter:
+    def list_providers(self):
+        return ["demo"]
+
+    def set_provider(self, pid):
+        pass
+
+    def fields(self):
+        return []
+
+    def scopes(self):
+        return []
+
+    def scope_label(self, scope_id, short=False):
+        return scope_id
+
+    def can_write(self, scope_id):
+        return True
+
+    def values_for_key(self, key):
+        return {}
+
+    def effective_for_key(self, key):
+        return None, None
+
+    def default_for_key(self, key):
+        return None
+
+    def target_path(self, scope_id):
+        assert scope_id == "project"
+        return Path("/tmp/project/settings.json")
+
+
+def test_app_shows_project_path():
+    if tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+    app = App(root, adapter=StubAdapter())
+    assert app._project_var.get() == "/tmp/project/settings.json"
+    root.destroy()

--- a/tests/test_field_row.py
+++ b/tests/test_field_row.py
@@ -95,3 +95,27 @@ def test_field_row_compact_mode():
     pills = _collect_pills(row)
     assert [p.text for p in pills] == ["Env", "User", "Project·Machine", "Default"]
     root.destroy()
+
+
+class NoDefaultAdapter(DummyAdapter):
+    def values_for_key(self, key):
+        return {"env": ValueInfo("e")}
+
+    def effective_for_key(self, key):
+        return "e", "env"
+
+    def default_for_key(self, key):
+        return None
+
+
+def test_field_row_hides_default_when_missing():
+    if tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+    row = FieldRow(root, NoDefaultAdapter(), "alpha", lambda k, s: None, compact=True)
+    pills = [p.text for p in _collect_pills(row)]
+    assert "Default" not in pills
+    root.destroy()


### PR DESCRIPTION
## Summary
- Launch the modern tkinter-based GUI from `sigil gui`
- Show current project path in the GUI header and allow initial provider selection
- Hide missing default pills and style default scope in black
- Add tests for project path display and default pill visibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b38ae0a4bc8328977eed52d8692517