### PR TITLE
Support environment variable scope

### DIFF
--- a/src/pysigil/settings_metadata.py
+++ b/src/pysigil/settings_metadata.py
@@ -604,6 +604,12 @@ class IniFileBackend:
             for k, v in data.items():
                 raw[k] = v
                 source[k] = scope
+        prefix = f"SIGIL_{provider_id.upper().replace('-', '_')}_"
+        for key, value in os.environ.items():
+            if key.startswith(prefix):
+                raw_key = key[len(prefix):].lower()
+                raw[raw_key] = value
+                source[raw_key] = "env"
         return raw, source
 
     def read_layers(self, provider_id: str) -> Mapping[str, Mapping[str, str]]:
@@ -611,6 +617,14 @@ class IniFileBackend:
         for scope, path in self._iter_read_paths(provider_id):
             data = self._read_sections(path).get(provider_id, {})
             layers[scope] = data
+        env_map: dict[str, str] = {}
+        prefix = f"SIGIL_{provider_id.upper().replace('-', '_')}_"
+        for key, value in os.environ.items():
+            if key.startswith(prefix):
+                raw_key = key[len(prefix):].lower()
+                env_map[raw_key] = value
+        if env_map:
+            layers["env"] = env_map
         return layers
 
     def write_key(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from pysigil import api
@@ -35,3 +36,20 @@ def test_unknown_provider(tmp_path):
     a = make_api(tmp_path)
     with pytest.raises(a.UnknownProviderError):
         a.handle("missing")
+
+
+def test_environment_scope(tmp_path, monkeypatch):
+    a = make_api(tmp_path)
+    a.register_provider("pkg")
+    h = a.handle("pkg")
+    h.add_field("api_field", "string")
+    h.set("api_field", "42", scope="environment")
+    assert os.environ["SIGIL_PKG_API_FIELD"] == "42"
+    val = h.get("api_field")
+    assert val.value == "42"
+    assert val.source == "env"
+    h.clear("api_field", scope="environment")
+    assert "SIGIL_PKG_API_FIELD" not in os.environ
+    val2 = h.get("api_field")
+    assert val2.value is None
+    assert val2.source is None


### PR DESCRIPTION
## Summary
- allow configuration provider APIs to read environment variables
- enable setting and clearing fields in the environment scope
- cover environment scope behaviour with tests

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/api.py src/pysigil/settings_metadata.py tests/test_api.py` *(fails: command not found / cannot install pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68b393058aac8328bc05bf5fed4e14c5