### PR TITLE
Show env scope like other scopes and display default in full mode

### DIFF
--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -98,13 +98,17 @@ class FieldRow(ttk.Frame):
         scopes = self.adapter.scopes()
         for scope in scopes:
             has_value = scope in values
-            if scope == "default" and not has_value:
+            if scope == "default" and not has_value and self.compact:
                 continue
             if self.compact and scope != "default" and not has_value:
                 continue
 
             can_write = self.adapter.can_write(scope)
-            if not can_write and scope != "default":
+            if (
+                not can_write
+                and scope != "default"
+                and not self.adapter.is_overlay(scope)
+            ):
                 state = "disabled"
             elif eff_src == scope:
                 state = "effective"


### PR DESCRIPTION
## Summary
- Treat env scope pills as present/effective instead of disabled overlays
- Always include the default scope pill in non-compact mode, even without a value
- Update field row tests for env scope behavior and default pill visibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b39583a7348328ac335c776222dda5