### PR TITLE
Improve Tk UI layout and remove lock icon

### DIFF
--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -93,12 +93,18 @@ class App:
         self._table = ttk.Frame(self.root)
         self._table.pack(fill="both", expand=True, padx=6, pady=6)
 
-        ttk.Label(self._table, text="Key").grid(row=0, column=0, sticky="w")
-        ttk.Label(self._table, text="Value (effective)").grid(
-            row=0, column=1, sticky="w"
+        style = ttk.Style(self.root)
+        style.configure("Title.TLabel", font=(None, 10, "bold"), anchor="center")
+
+        ttk.Label(self._table, text="Key", style="Title.TLabel").grid(
+            row=0, column=0, sticky="ew"
         )
-        ttk.Label(self._table, text="Scopes").grid(row=0, column=2, sticky="w")
-        ttk.Label(self._table, text="Edit…").grid(row=0, column=3, sticky="w")
+        ttk.Label(
+            self._table, text="Value (effective)", style="Title.TLabel"
+        ).grid(row=0, column=1, sticky="ew")
+        ttk.Label(self._table, text="Scopes", style="Title.TLabel").grid(
+            row=0, column=2, sticky="ew"
+        )
 
         self._table.columnconfigure(1, weight=1)
 
@@ -205,7 +211,7 @@ class App:
         self.compact = bool(self._compact_var.get())
         for row in self.rows.values():
             row.set_compact(self.compact)
-        self._schedule_align()
+        self._align_rows()
 
     # -- alignment -----------------------------------------------------
     def _schedule_align(self) -> None:

--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -80,15 +80,14 @@ class FieldRow(ttk.Frame):
         if tk is None:  # pragma: no cover - defensive
             return
 
-        # locked effective value -------------------------------------------------
+        # effective value -------------------------------------------------------
         eff_val, eff_src = self.adapter.effective_for_key(self.key)
         val_txt = "—" if eff_val is None else str(eff_val)
         if eff_src is None:
             src_txt = "—"
         else:
             src_txt = self.adapter.scope_label(eff_src)
-        lock = "\U0001F512 "
-        self.var_eff.set(f"{lock}{val_txt}  ({src_txt})")
+        self.var_eff.set(f"{val_txt}  ({src_txt})")
 
         # rebuild pills ----------------------------------------------------------
         for child in list(self.pills.winfo_children()):

--- a/tests/test_field_row.py
+++ b/tests/test_field_row.py
@@ -87,7 +87,7 @@ def test_field_row_full_mode(monkeypatch):
             break
     assert clicks == [("alpha", "user")]
     lock_txt = row.var_eff.get()
-    assert lock_txt.startswith("\U0001F512 u")
+    assert lock_txt.startswith("u")
     assert "(User)" in lock_txt
     root.destroy()
 


### PR DESCRIPTION
## Summary
- Center and bold table headers with a reusable title style
- Remove lock icon from effective value display
- Re-align rows when toggling compact mode

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/ui/tk/__init__.py src/pysigil/ui/tk/rows.py tests/test_field_row.py` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b39b23c4548328933b0de1fdd9e71f