### PR TITLE
Reset minsize when toggling compact mode to allow scope column to shrink

### DIFF
--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -224,6 +224,11 @@ class App:
         self._align_pending = False
         if not self.rows:
             return
+        # reset previous alignment so widths can shrink when necessary
+        for r in self.rows.values():
+            r.grid_columnconfigure(0, minsize=0)
+            r.grid_columnconfigure(2, minsize=0)
+
         self.root.update_idletasks()
         key_w = max(r.lbl_key.winfo_reqwidth() for r in self.rows.values())
         pills_w = max(r.pills.winfo_reqwidth() for r in self.rows.values())


### PR DESCRIPTION
## Summary
- Reset alignment minsize before measuring widths to allow pills column to shrink after toggling compact mode

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5b34259b88328b6325a5179f7170f