### PR TITLE
Fix project-local path when switching project root

### DIFF
--- a/src/pysigil/core.py
+++ b/src/pysigil/core.py
@@ -471,13 +471,26 @@ class Sigil:
 
     @contextmanager
     def project(self, path: Path):
-        old_path = self.project_path
+        new_path = Path(path)
+        if new_path.suffix == "" or new_path.name != self.settings_filename:
+            new_path = new_path / self.settings_filename
+
+        old_project = self.project_path
+        old_project_local = self.project_local_path
         old_default = self._default_scope
-        self.project_path = path
+
+        self.project_path = new_path
+        self.project_local_path = new_path.parent / f"settings-local-{self._host}.ini"
+        self._paths["project"] = self.project_path
+        self._paths["project-local"] = self.project_local_path
         self._default_scope = "project"
+        self.invalidate_cache()
         try:
             yield self
         finally:
-            self.project_path = old_path
+            self.project_path = old_project
+            self.project_local_path = old_project_local
+            self._paths["project"] = self.project_path
+            self._paths["project-local"] = self.project_local_path
             self._default_scope = old_default
             self.invalidate_cache()

--- a/tests/test_project_context.py
+++ b/tests/test_project_context.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from pysigil import Sigil
+from pysigil.policy import policy
+
+
+def test_project_context_updates_local_path(tmp_path: Path) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    for root in (root_a, root_b):
+        (root / ".sigil").mkdir(parents=True)
+        (root / ".sigil-root").touch()
+
+    cwd = os.getcwd()
+    os.chdir(root_a)
+    try:
+        s = Sigil("demo", user_scope=tmp_path / "user", policy=policy)
+        host = s._host
+        old_local = root_a / ".sigil" / f"settings-local-{host}.ini"
+
+        with s.project(root_b / ".sigil" / "settings.ini"):
+            s.set_pref("foo", "bar", scope="project-local")
+            expected = root_b / ".sigil" / f"settings-local-{host}.ini"
+            assert s.project_local_path == expected
+            assert s.path_for_scope("project-local") == expected
+            assert expected.exists()
+            assert not old_local.exists()
+    finally:
+        os.chdir(cwd)
+    # path restored
+    assert s.project_local_path == old_local


### PR DESCRIPTION
## Summary
- Update `Sigil.project` context manager to keep project and project-local paths in sync
- Add regression test covering project-local writes in a project context

## Testing
- `pytest tests/test_project_context.py::test_project_context_updates_local_path -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c40aa8ac832892dfdc8f6e6089ef