### PR TITLE
Fix GUI handling of non-string preference values

### DIFF
--- a/src/pysigil/gui/__init__.py
+++ b/src/pysigil/gui/__init__.py
@@ -331,7 +331,7 @@ def launch_gui(
                 iid=key,
                 values=(
                     key,
-                    val,
+                    "" if val is None else str(val),
                     label_map.get(src, src),
                     "Override \u25BE   Reset \u25BE",
                 ),
@@ -354,8 +354,10 @@ def launch_gui(
     def _on_override(key: str, scope: str) -> None:
         if _sigil_instance is None:
             return
-        current = _sigil_instance.get_pref(key) or ""
-        res = _open_value_dialog("edit", scope, key=key, value=str(current))
+        current = _sigil_instance.get_pref(key)
+        res = _open_value_dialog(
+            "edit", scope, key=key, value="" if current is None else str(current)
+        )
 
         if not res:
             return


### PR DESCRIPTION
## Summary
- ensure GUI tree displays non-string preference values
- preserve falsy values when editing preferences in GUI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5c826f04c8328b2166ed7625c4969