### PR TITLE
fix: validate GUI non-string values

### DIFF
--- a/src/pysigil/gui/__init__.py
+++ b/src/pysigil/gui/__init__.py
@@ -352,9 +352,12 @@ def launch_gui(
                 int(val)
             elif isinstance(current, float):
                 float(val)
-            elif isinstance(current, list | dict):
-                json.loads(val)
+            elif isinstance(current, (list, dict)):
+                data = json.loads(val)
+                if not isinstance(data, type(current)):
+                    raise ValueError(f"Expected {type(current).__name__} for {key}")
         except Exception as exc:
+            logger.error("invalid value %r for %s: %s", val, key, exc)
             if messagebox is not None:
                 messagebox.showerror("Invalid value", str(exc), parent=root)
             return False

--- a/src/pysigil/gui/__init__.py
+++ b/src/pysigil/gui/__init__.py
@@ -352,7 +352,7 @@ def launch_gui(
                 int(val)
             elif isinstance(current, float):
                 float(val)
-            elif isinstance(current, (list, dict)):
+            elif isinstance(current, list | dict):
                 data = json.loads(val)
                 if not isinstance(data, type(current)):
                     raise ValueError(f"Expected {type(current).__name__} for {key}")


### PR DESCRIPTION
## Summary
- validate JSON and numeric values before saving
- log and show popup when preference validation fails

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5cd5a251c8328970b2eff82940ae2