### PR TITLE
Move author setup GUI under ui.tk

### DIFF
--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -198,7 +198,7 @@ def gui_cmd(args: argparse.Namespace) -> int:  # pragma: no cover - GUI interact
 
 
 def setup_cmd(_: argparse.Namespace) -> int:  # pragma: no cover - GUI interactions
-    from .gui.author import main as author_main
+    from .ui.tk.author import main as author_main
 
     author_main()
     return 0

--- a/src/pysigil/ui/tk/author.py
+++ b/src/pysigil/ui/tk/author.py
@@ -7,14 +7,14 @@ import webbrowser
 from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
 
-from ..authoring import DevLinkError, _dev_dir, link, normalize_provider_id
-from ..resolver import (
+from ...authoring import DevLinkError, _dev_dir, link, normalize_provider_id
+from ...resolver import (
     default_provider_id,
     ensure_defaults_file,
     find_package_dir,
     read_dist_name_from_pyproject,
 )
-from ..root import ProjectRootNotFoundError, find_project_root
+from ...root import ProjectRootNotFoundError, find_project_root
 
 APP_TITLE = "Sigil – Register Package Defaults"
 


### PR DESCRIPTION
## Summary
- relocate author registration GUI to `pysigil.ui.tk.author`
- update CLI setup command to reference new module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d2e421708328b285c539f0b59275