### PR TITLE
Enable author mode flag and default-scope authoring

### DIFF
--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -47,6 +47,19 @@ from .resolver import (
 from .root import ProjectRootNotFoundError, find_project_root
 
 
+AUTHOR_FLAG_ENV = "SIGIL_AUTHOR"
+
+
+def author_mode_enabled(args: argparse.Namespace | None = None) -> bool:
+    """Return True if author mode should be enabled."""
+    if args and getattr(args, "author", False):
+        return True
+    if os.environ.get(AUTHOR_FLAG_ENV):
+        return True
+    cfg = Path.home() / ".sigil" / "author.toml"
+    return cfg.is_file()
+
+
 def _launch(path: Path) -> None:  # pragma: no cover - best effort
     try:
         if sys.platform.startswith("win"):
@@ -193,7 +206,7 @@ def export_cmd(args: argparse.Namespace) -> int:
 
 
 def gui_cmd(args: argparse.Namespace) -> int:  # pragma: no cover - GUI interactions
-    launch_gui(initial_provider=args.app)
+    launch_gui(initial_provider=args.app, author_mode=author_mode_enabled(args))
     return 0
 
 
@@ -316,6 +329,7 @@ def author_list_links(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="sigil", description="Sigil command line interface.")
+    parser.add_argument("--author", action="store_true", help="Enable author mode")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # paths command

--- a/src/pysigil/ui/provider_adapter.py
+++ b/src/pysigil/ui/provider_adapter.py
@@ -19,7 +19,8 @@ class ValueInfo:
 class ProviderAdapter:
     """Adapter exposing provider data and configuration values for the UI."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, author_mode: bool = False) -> None:
+        self.author_mode = author_mode
         self._handle: api.ProviderHandle | None = None
         self._default_path: Path | None = None
         self._default_writable = False
@@ -86,7 +87,7 @@ class ProviderAdapter:
     def can_write(self, scope_id: str) -> bool:
         """Return ``True`` if *scope_id* is writable according to policy."""
         if scope_id == "default":
-            return self._default_writable
+            return self.author_mode and self._default_writable
         try:
             return policy.allows(scope_id)
         except Exception:  # pragma: no cover - defensive
@@ -133,14 +134,18 @@ class ProviderAdapter:
     # ------------------------------------------------------------------
     def set_value(self, key: str, scope_id: str, value: object) -> None:
         handle = self._require_handle()
-        if scope_id == "default" and self._default_writable:
+        if scope_id == "default":
+            if not (self.author_mode and self._default_writable):
+                raise PermissionError("default scope is read-only")
             handle._manager().set(key, value, scope="default")  # type: ignore[attr-defined]
-        else:
-            handle.set(key, value, scope=scope_id)
+            return
+        handle.set(key, value, scope=scope_id)
 
     def clear_value(self, key: str, scope_id: str) -> None:
         handle = self._require_handle()
-        if scope_id == "default" and self._default_writable:
+        if scope_id == "default":
+            if not (self.author_mode and self._default_writable):
+                raise PermissionError("default scope is read-only")
             handle._manager().clear(key, scope="default")  # type: ignore[attr-defined]
             return
         handle.clear(key, scope=scope_id)


### PR DESCRIPTION
## Summary
- add `--author` flag, env var, and config file detection to toggle author mode
- allow default-scope writes only in author mode and surface state in UI core
- show an "Author Tools…" button in the Tk header when author mode is active

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5d64a58f0832884707585f9a9d98a