### PR TITLE
Harden settings GUI and scope policy

### DIFF
--- a/src/pysigil/ui/tk/dialogs.py
+++ b/src/pysigil/ui/tk/dialogs.py
@@ -70,7 +70,10 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
                 entry.insert(0, str(vinfo.value))
 
             can_write = adapter.can_write(scope)
-            if scope == "env" or adapter.is_overlay(scope):
+            if scope == "default":
+                entry.state(["readonly"])
+                can_write = False
+            elif scope == "env" or adapter.is_overlay(scope):
                 entry.state(["readonly"])
                 can_write = False
             elif not can_write:
@@ -113,6 +116,9 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
         value = self.entries[scope].get()
         try:
             self.on_edit_save(self.key, scope, value)
+        except PermissionError as exc:
+            if messagebox is not None:
+                messagebox.showinfo("Read-only", str(exc), parent=self)
         except Exception as exc:  # pragma: no cover - defensive
             if messagebox is not None:
                 messagebox.showerror("Error", str(exc), parent=self)
@@ -122,6 +128,10 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
             return
         try:
             self.on_edit_remove(self.key, scope)
+        except PermissionError as exc:
+            if messagebox is not None:
+                messagebox.showinfo("Read-only", str(exc), parent=self)
+            return
         except Exception as exc:  # pragma: no cover - defensive
             if messagebox is not None:
                 messagebox.showerror("Error", str(exc), parent=self)

--- a/src/pysigil/ui/tk/widgets.py
+++ b/src/pysigil/ui/tk/widgets.py
@@ -103,13 +103,15 @@ class PillButton(tk.Canvas):
         clickable: bool = True,
         on_click: Callable[[], None] | None = None,
         tooltip_title: str | None = None,
+        locked: bool = False,
     ) -> None:
         super().__init__(master, height=28, highlightthickness=0, bd=0)
         self.text = text
         self.tooltip_title = tooltip_title or text
         self.color = color
         self.state = state
-        self.clickable = clickable and state != "disabled"
+        self.locked = locked
+        self.clickable = clickable
         self.on_click = on_click
         self.font = tkfont.Font(size=9, weight="bold") if tkfont else None
         self.value_provider = value_provider
@@ -141,7 +143,8 @@ class PillButton(tk.Canvas):
         if self.font is None:
             return 64
         text_w = self.font.measure(self.text)
-        return max(64, text_w + self.pad_x * 2)
+        extra = 10 if self.locked else 0
+        return max(64, text_w + self.pad_x * 2 + extra)
 
     def _draw(self, initial: bool = False) -> None:
         w = self._measure_width()
@@ -174,6 +177,8 @@ class PillButton(tk.Canvas):
         r = self.rad
         self._round_rect(1, 1, w - 1, 26, r, fill=fill, outline=outline, width=border_w)
         self.create_text(w / 2, 14, text=self.text, fill=fg, font=self.font)
+        if self.locked:
+            self.create_text(w - 10, 14, text="\u1F512", fill=fg, font=self.font)
         if self.focus_displayof() is self:
             self.create_rectangle(3, 3, w - 3, 24, outline="#111", dash=(2, 2))
 

--- a/tests/manual/manual_author_gui.py
+++ b/tests/manual/manual_author_gui.py
@@ -1,0 +1,5 @@
+"""Manual helper to launch the author registration GUI."""
+from pysigil.ui.tk.author import main
+
+if __name__ == "__main__":  # pragma: no cover - manual only
+    main()

--- a/tests/ui/test_edit_dialog.py
+++ b/tests/ui/test_edit_dialog.py
@@ -1,0 +1,48 @@
+import pytest
+
+try:
+    import tkinter as tk
+    from tkinter import ttk
+except Exception:  # pragma: no cover - tkinter missing
+    tk = None  # type: ignore
+    ttk = None  # type: ignore
+
+from pysigil.ui.tk.dialogs import EditDialog
+from pysigil.ui.provider_adapter import ValueInfo
+
+
+class DummyAdapter:
+    def scopes(self):
+        return ["user", "default"]
+
+    def scope_label(self, scope, short=False):
+        return scope.title() if short else scope.title()
+
+    def values_for_key(self, key):
+        return {"default": ValueInfo("d")}
+
+    def can_write(self, scope):
+        return scope != "default"
+
+    def is_overlay(self, scope):
+        return False
+
+
+def test_edit_dialog_default_readonly():
+    if tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+    dlg = EditDialog(root, DummyAdapter(), "alpha")
+    entry = dlg.entries["default"]
+    assert entry.instate(["readonly"])  # default is read-only
+    row = entry.grid_info()["row"]
+    body = entry.master
+    btn_save = body.grid_slaves(row=row, column=2)[0]
+    btn_remove = body.grid_slaves(row=row, column=3)[0]
+    assert btn_save.instate(["disabled"])
+    assert btn_remove.instate(["disabled"])
+    dlg.destroy()
+    root.destroy()


### PR DESCRIPTION
## Summary
- Lock default scope editing and display padlock icons on read-only pills
- Surface hints for read-only scopes and enforce policy in the provider adapter
- Add manual launcher for author GUI and accompanying tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5d9e3c948832888c65c04dd74445a