### PR TITLE
Add author tools window skeleton

### DIFF
--- a/src/pysigil/ui/tk/author_tools.py
+++ b/src/pysigil/ui/tk/author_tools.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+try:  # pragma: no cover - tkinter availability depends on environment
+    import tkinter as tk
+    from tkinter import ttk
+except Exception:  # pragma: no cover - fallback when tkinter missing
+    tk = None  # type: ignore
+    ttk = None  # type: ignore
+
+from ..core import AppCore
+
+
+class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
+    """Toplevel window exposing authoring tools.
+
+    The implementation intentionally keeps the interface minimal.  It
+    presents a tabbed notebook with three placeholder tabs: *Fields*,
+    *Defaults* and *Untracked*.  Content is read-only for now and pulled
+    from :class:`~pysigil.ui.core.AppCore`.
+    """
+
+    def __init__(self, master: tk.Misc, core: AppCore) -> None:
+        super().__init__(master)
+        self.title("Sigil – Author Tools")
+        self.core = core
+        self._build()
+        self._populate_fields()
+
+    # ------------------------------------------------------------------
+    def _build(self) -> None:
+        self.geometry("640x480")
+        nb = ttk.Notebook(self)
+        self._tab_fields = ttk.Frame(nb)
+        self._tab_defaults = ttk.Frame(nb)
+        self._tab_untracked = ttk.Frame(nb)
+        nb.add(self._tab_fields, text="Fields")
+        nb.add(self._tab_defaults, text="Defaults")
+        nb.add(self._tab_untracked, text="Untracked")
+        nb.pack(fill="both", expand=True)
+
+        self._fields_list = tk.Listbox(self._tab_fields)
+        self._fields_list.pack(fill="both", expand=True, padx=6, pady=6)
+
+    def _populate_fields(self) -> None:
+        self._fields_list.delete(0, tk.END)
+        for info in self.core.state.fields:
+            self._fields_list.insert(tk.END, info.key)

--- a/tests/manual/manual_author_gui.py
+++ b/tests/manual/manual_author_gui.py
@@ -1,5 +1,8 @@
-"""Manual helper to launch the author registration GUI."""
-from pysigil.ui.tk.author import main
+"""Manual helper to launch the author tools GUI."""
+
+from pysigil.ui.tk import App
 
 if __name__ == "__main__":  # pragma: no cover - manual only
-    main()
+    app = App(author_mode=True, initial_provider="sigil-dummy")
+    app._open_author_tools()
+    app.root.mainloop()

--- a/tests/test_author_tools_window.py
+++ b/tests/test_author_tools_window.py
@@ -1,0 +1,34 @@
+try:  # pragma: no cover - tkinter availability depends on the env
+    import tkinter as tk
+except Exception:  # pragma: no cover - fallback when tkinter missing
+    tk = None  # type: ignore
+
+import pytest
+
+from pysigil.ui.tk import App
+
+
+def _make_app(author_mode: bool) -> App:
+    if tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+    return App(root, author_mode=author_mode)
+
+
+def test_author_tools_requires_author_mode():
+    app = _make_app(author_mode=False)
+    with pytest.raises(RuntimeError):
+        app._open_author_tools()
+    app.root.destroy()
+
+
+def test_author_tools_window_opens_in_author_mode():
+    app = _make_app(author_mode=True)
+    app._open_author_tools()
+    assert app._author_tools is not None
+    assert bool(app._author_tools.winfo_exists())
+    app._author_tools.destroy()
+    app.root.destroy()


### PR DESCRIPTION
## Summary
- add tabbed Author Tools toplevel with placeholders
- wire author tools into Tk App with author-mode gating
- document manual helper and tests for author tools

## Testing
- `pytest tests/test_author_tools_window.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5de38e8b48328bb6877a4f7a5d1a2