### PR TITLE
Support field options metadata

### DIFF
--- a/src/pysigil/api.py
+++ b/src/pysigil/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dataclass_field
 from pathlib import Path
 from typing import Any, Literal
 import os
@@ -52,6 +52,7 @@ class FieldInfo:
     type: str
     label: str | None
     description: str | None
+    options: dict[str, Any] = dataclass_field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -75,6 +76,7 @@ def _field_info(spec: FieldSpec) -> FieldInfo:
         type=spec.type,
         label=spec.label,
         description=spec.description,
+        options=spec.options,
     )
 
 
@@ -168,6 +170,7 @@ class ProviderHandle:
         *,
         label: str | None = None,
         description: str | None = None,
+        options: Mapping[str, Any] | None = None,
         init_scope: Literal[
             "user", "user-local", "project", "project-local", "environment"
         ] | None = "user",
@@ -179,6 +182,7 @@ class ProviderHandle:
                 type=type,
                 label=label,
                 description=description,
+                options=dict(options) if options is not None else None,
             )
         except DuplicateFieldError as exc:
             raise DuplicateFieldError(key) from exc
@@ -199,6 +203,7 @@ class ProviderHandle:
         new_type: str | None = None,
         label: str | None = None,
         description: str | None = None,
+        options: Mapping[str, Any] | None = None,
         on_type_change: Literal["convert", "clear"] = "convert",
         migrate_scopes: tuple[
             Literal["user", "user-local", "project", "project-local"], ...
@@ -212,6 +217,7 @@ class ProviderHandle:
                 new_type=new_type,
                 label=label,
                 description=description,
+                options=dict(options) if options is not None else None,
                 on_type_change=on_type_change,
             )
         except UnknownFieldError as exc:

--- a/src/pysigil/orchestrator.py
+++ b/src/pysigil/orchestrator.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Mapping
 
 from .authoring import normalize_provider_id
 from .errors import (
@@ -143,6 +143,7 @@ class Orchestrator:
         type: str,
         label: str | None = None,
         description: str | None = None,
+        options: Mapping[str, object] | None = None,
     ) -> FieldSpec:
         """Add a new field to a provider specification.
 
@@ -160,7 +161,13 @@ class Orchestrator:
         spec = self.spec_backend.get_spec(pid)
         if key in {f.key for f in spec.fields}:
             raise DuplicateFieldError(key)
-        field = FieldSpec(key=key, type=type, label=label, description=description)
+        field = FieldSpec(
+            key=key,
+            type=type,
+            label=label,
+            description=description,
+            options=dict(options) if options is not None else {},
+        )
         new_spec = replace(spec, fields=tuple(spec.fields) + (field,))
         etag = self.spec_backend.etag(pid)
         try:
@@ -183,6 +190,7 @@ class Orchestrator:
         new_type: str | None = None,
         label: str | None = None,
         description: str | None = None,
+        options: Mapping[str, object] | None = None,
         on_type_change: Literal["convert", "clear"] = "convert",
     ) -> FieldSpec:
         """Modify an existing field definition.
@@ -220,6 +228,7 @@ class Orchestrator:
             type=nt,
             label=old_field.label if label is None else label,
             description=old_field.description if description is None else description,
+            options=old_field.options if options is None else dict(options),
         )
 
         raw_map, source_map = self.config_backend.read_merged(pid)

--- a/src/pysigil/settings_metadata.py
+++ b/src/pysigil/settings_metadata.py
@@ -199,6 +199,7 @@ class FieldSpec:
     type: str
     label: str | None = None
     description: str | None = None
+    options: dict[str, Any] = dataclass_field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.type not in TYPE_REGISTRY:
@@ -212,6 +213,7 @@ class FieldSpec:
             "type": self.type,
             "label": self.label,
             "description": self.description,
+            "options": self.options,
         }
 
 
@@ -382,6 +384,8 @@ class IniSpecBackend:
                 parser.set(section, "label", field.label)
             if field.description is not None:
                 parser.set(section, "description", field.description)
+            if field.options:
+                parser.set(section, "options", json.dumps(field.options, sort_keys=True))
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(path.suffix + ".tmp")
         with tmp.open("w") as fh:
@@ -410,6 +414,7 @@ class IniSpecBackend:
                     type=data.get("type", "string"),
                     label=data.get("label"),
                     description=data.get("description"),
+                    options=json.loads(data.get("options", "{}")),
                 )
             )
         spec = ProviderSpec(

--- a/src/pysigil/ui/core.py
+++ b/src/pysigil/ui/core.py
@@ -117,6 +117,7 @@ class ProvidersService:
         *,
         label: str | None = None,
         description: str | None = None,
+        options: Dict[str, Any] | None = None,
         init_scope: Literal["user", "project"] | None = "user",
     ) -> api.FieldInfo:
         return api.handle(pid).add_field(
@@ -124,6 +125,7 @@ class ProvidersService:
             type,
             label=label,
             description=description,
+            options=options,
             init_scope=init_scope,
         )
 
@@ -172,6 +174,7 @@ class ProvidersService:
         new_type: str | None = None,
         label: str | None = None,
         description: str | None = None,
+        options: Dict[str, Any] | None = None,
         on_type_change: Literal["convert", "clear"] = "convert",
         migrate_scopes: tuple[Literal["user", "project"], ...] = ("user",),
     ) -> api.FieldInfo:
@@ -181,6 +184,7 @@ class ProvidersService:
             new_type=new_type,
             label=label,
             description=description,
+            options=options,
             on_type_change=on_type_change,
             migrate_scopes=migrate_scopes,
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,11 +24,12 @@ def test_register_and_set(tmp_path):
     info2 = a.register_provider("my-pkg")
     assert info2.provider_id == "my-pkg"
     h = a.handle("my-pkg")
-    h.add_field("retries", "integer")
+    h.add_field("retries", "integer", options={"min": 0})
     h.set("retries", 5)
     val = h.get("retries")
     assert val.value == 5
     assert val.source == "user"
+    assert h.fields()[0].options == {"min": 0}
     assert "my-pkg" in a.providers()
 
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -20,11 +20,19 @@ def _make_orch(tmp_path: Path) -> Orchestrator:
 def test_register_add_set_get(tmp_path: Path) -> None:
     orch = _make_orch(tmp_path)
     orch.register_provider("my-pkg", title="My Package")
-    orch.add_field("my-pkg", key="retries", type="integer", label="Retries")
+    orch.add_field(
+        "my-pkg",
+        key="retries",
+        type="integer",
+        label="Retries",
+        options={"min": 0},
+    )
     orch.set_value("my-pkg", "retries", 5)
     eff = orch.get_effective("my-pkg")
     assert eff["retries"].value == 5
     assert eff["retries"].source == "user"
+    spec = orch.reload_spec("my-pkg")
+    assert spec.fields[0].options == {"min": 0}
 
 
 def test_edit_field_rename_migrates_value(tmp_path: Path) -> None:

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -17,9 +17,15 @@ def test_register_and_add_field(tmp_path):
     assert spec.title == "Demo"
     assert spec.fields == ()
 
-    field = FieldSpec(key="retries", type="integer", label="Retries")
+    field = FieldSpec(
+        key="retries",
+        type="integer",
+        label="Retries",
+        options={"min": 0},
+    )
     add_field_spec(path, field)
     spec2 = load_provider_spec(path)
     assert len(spec2.fields) == 1
     assert spec2.fields[0].key == "retries"
     assert spec2.fields[0].type == "integer"
+    assert spec2.fields[0].options == {"min": 0}


### PR DESCRIPTION
## Summary
- allow configuration fields to carry arbitrary options metadata
- persist field options in INI and JSON provider specs
- expose options through API and orchestrator add/edit field helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e2b07b2c8328a2aa4cbc2ff35031