### PR TITLE
Introduce FieldType registry for settings metadata

### DIFF
--- a/src/pysigil/orchestrator.py
+++ b/src/pysigil/orchestrator.py
@@ -240,7 +240,7 @@ class Orchestrator:
             new_raw = raw
             if nt != old_field.type:
                 if on_type_change == "convert":
-                    adapter = TYPE_REGISTRY[nt]
+                    adapter = TYPE_REGISTRY[nt].adapter
                     try:
                         value = adapter.parse(raw)
                         new_raw = adapter.serialize(value)
@@ -489,7 +489,7 @@ Set multiple values for *provider_id* at once.
                 field = fields.get(key)
                 if field is None:
                     raise UnknownFieldError(key)
-                adapter = TYPE_REGISTRY[field.type]
+                adapter = TYPE_REGISTRY[field.type].adapter
                 try:
                     adapter.validate(value, field)
                 except (TypeError, ValueError) as exc:
@@ -515,7 +515,7 @@ Set multiple values for *provider_id* at once.
         """
         mgr = self._manager(provider_id)
         field = mgr._field_for(key)  # pylint: disable=protected-access
-        adapter = TYPE_REGISTRY[field.type]
+        adapter = TYPE_REGISTRY[field.type].adapter
         try:
             adapter.validate(value, field)
         except (TypeError, ValueError) as exc:
@@ -536,7 +536,7 @@ Set multiple values for *provider_id* at once.
         raw_map, _ = self.config_backend.read_merged(pid)
         result: dict[str, str | None] = {}
         for field in spec.fields:
-            adapter = TYPE_REGISTRY[field.type]
+            adapter = TYPE_REGISTRY[field.type].adapter
             raw = raw_map.get(field.key)
             try:
                 adapter.parse(raw)

--- a/src/pysigil/ui/author_adapter.py
+++ b/src/pysigil/ui/author_adapter.py
@@ -243,9 +243,9 @@ class AuthorAdapter:
 
         if raw is None:
             return "string"
-        for typ, adapter in TYPE_REGISTRY.items():
+        for typ, field_type in TYPE_REGISTRY.items():
             try:
-                adapter.parse(raw)
+                field_type.adapter.parse(raw)
                 return typ
             except Exception:
                 continue

--- a/src/pysigil/ui/widgets.py
+++ b/src/pysigil/ui/widgets.py
@@ -8,7 +8,10 @@ implementations for other GUI toolkits.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Callable, Protocol, Dict, Any
+
+from ..settings_metadata import TYPE_REGISTRY
 
 try:  # pragma: no cover - importing tkinter is environment dependent
     import tkinter as tk
@@ -93,11 +96,18 @@ def _boolean_check(master) -> EditorWidget:
     return frame  # type: ignore[return-value]
 
 
+# Register widget implementations with the type registry
+TYPE_REGISTRY["string"] = replace(TYPE_REGISTRY["string"], value_widget=_simple_entry)
+TYPE_REGISTRY["integer"] = replace(TYPE_REGISTRY["integer"], value_widget=_simple_entry)
+TYPE_REGISTRY["number"] = replace(TYPE_REGISTRY["number"], value_widget=_simple_entry)
+TYPE_REGISTRY["boolean"] = replace(TYPE_REGISTRY["boolean"], value_widget=_boolean_check)
+
+
 FIELD_WIDGETS: Dict[str, Callable[[Any], EditorWidget]] = {
-    "string": _simple_entry,
-    "integer": _simple_entry,
-    "number": _simple_entry,
-    "boolean": _boolean_check,
+    key: ft.value_widget  # type: ignore[assignment]
+    for key, ft in TYPE_REGISTRY.items()
+    if ft.value_widget is not None
 }
+
 
 __all__ = ["EditorWidget", "FIELD_WIDGETS"]


### PR DESCRIPTION
## Summary
- introduce `FieldType` dataclass and store adapters and widgets in type registry
- wire tk editor widgets into registry and derive `FIELD_WIDGETS`
- adjust orchestrator and authoring adapters to use `FieldType.adapter`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e95d743083288d574ccd17f5514e