### PR TITLE
Add OptionsForm utility for editing field options

### DIFF
--- a/src/pysigil/settings_metadata.py
+++ b/src/pysigil/settings_metadata.py
@@ -145,6 +145,26 @@ class BooleanAdapter:
         if value is not None and not isinstance(value, bool):
             raise TypeError("expected bool")
 
+
+class StringListAdapter:
+    """Adapter for lists of strings."""
+
+    def parse(self, raw: str | None) -> list[str]:
+        if not raw:
+            return []
+        return [p.strip() for p in raw.split(",") if p.strip()]
+
+    def serialize(self, value: Any) -> str:
+        if not isinstance(value, list) or not all(isinstance(p, str) for p in value):
+            raise TypeError("expected list[str]")
+        return ", ".join(value)
+
+    def validate(self, value: Any, spec: FieldSpec) -> None:
+        if value is not None and (
+            not isinstance(value, list) or not all(isinstance(p, str) for p in value)
+        ):
+            raise TypeError("expected list[str]")
+
 @dataclass(frozen=True)
 class FieldType:
     """Metadata describing a supported field type."""
@@ -160,6 +180,7 @@ TYPE_REGISTRY: dict[str, FieldType] = {
     "integer": FieldType(IntegerAdapter()),
     "number": FieldType(NumberAdapter()),
     "boolean": FieldType(BooleanAdapter()),
+    "string_list": FieldType(StringListAdapter()),
 }
 
 _PEP503_RE = re.compile(r"^[a-z0-9]+(?:[._-][a-z0-9]+)*$")
@@ -936,6 +957,7 @@ __all__ = [
     "DuplicateProviderError",
     "ConflictError",
     "StringAdapter",
+    "StringListAdapter",
     "TYPE_REGISTRY",
     "TypeAdapter",
     "add_field_spec",

--- a/src/pysigil/ui/__init__.py
+++ b/src/pysigil/ui/__init__.py
@@ -8,4 +8,4 @@ changes to the core logic.
 
 from __future__ import annotations
 
-__all__ = ["core", "tk", "widgets"]
+__all__ = ["core", "tk", "widgets", "options_form"]

--- a/src/pysigil/ui/options_form.py
+++ b/src/pysigil/ui/options_form.py
@@ -1,0 +1,165 @@
+"""Form utility for editing field options.
+
+The :class:`OptionsForm` class introspects the ``option_model`` dataclass
+associated with a :class:`~pysigil.settings_metadata.FieldType` and renders
+appropriate editor widgets for each field.  The widget layer itself is kept
+very small and reuses the generic editor widgets exposed by
+:mod:`pysigil.ui.widgets`.
+
+Only a subset of basic field types is currently supported: ``str``, ``int``,
+``float``, ``bool`` and ``list[str]``.  For more elaborate editors a
+:class:`~pysigil.settings_metadata.FieldType` can supply its own ``option_widget``
+which is used instead of the automatic dataclass based rendering.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, fields, is_dataclass
+from typing import Any, Mapping, get_args, get_origin, Union
+
+from ..settings_metadata import TYPE_REGISTRY, FieldType
+from .widgets import EditorWidget
+
+try:  # pragma: no cover - importing tkinter is environment dependent
+    import tkinter as tk  # type: ignore
+    from tkinter import ttk  # type: ignore
+except Exception:  # pragma: no cover - fallback when tkinter missing
+    tk = None  # type: ignore
+    ttk = None  # type: ignore
+
+
+class OptionsForm(ttk.Frame):
+    """Render editors for a field type's option model."""
+
+    def __init__(self, master, field_type: str | FieldType) -> None:
+        if tk is None or ttk is None:  # pragma: no cover - tkinter missing
+            raise RuntimeError("tkinter is required for OptionsForm")
+        super().__init__(master)
+        self._ft = TYPE_REGISTRY[field_type] if isinstance(field_type, str) else field_type
+        self._option_model = self._ft.option_model
+        self._widgets: dict[str, EditorWidget] = {}
+        self._fields: dict[str, tuple[str, bool]] = {}
+        self._custom: EditorWidget | None = None
+        if self._ft.option_widget is not None:
+            self._custom = self._ft.option_widget(self)
+        elif self._option_model is not None and is_dataclass(self._option_model):
+            self._build_from_model()
+        # when there is neither a custom widget nor option model the form stays empty
+
+    # ------------------------------------------------------------------
+    def _build_from_model(self) -> None:
+        assert self._option_model is not None
+        for row, f in enumerate(fields(self._option_model)):
+            key, optional = self._field_key(f.type)
+            ft = TYPE_REGISTRY[key]
+            if ft.value_widget is None:
+                raise TypeError(f"no widget for option field type {key}")
+            widget = ft.value_widget(self)  # type: ignore[assignment]
+            label = ttk.Label(self, text=f.name.replace("_", " "))
+            label.grid(row=row, column=0, sticky="w", padx=4, pady=2)
+            widget.grid(row=row, column=1, sticky="ew", padx=4, pady=2)
+            self._widgets[f.name] = widget
+            self._fields[f.name] = (key, optional)
+        self.columnconfigure(1, weight=1)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _unwrap_optional(tp: Any) -> tuple[bool, Any]:
+        origin = get_origin(tp)
+        if origin is Union:
+            args = [a for a in get_args(tp) if a is not type(None)]
+            if len(args) == 1:
+                return True, args[0]
+        return False, tp
+
+    def _field_key(self, tp: Any) -> tuple[str, bool]:
+        optional, base = self._unwrap_optional(tp)
+        origin = get_origin(base)
+        if origin is list and get_args(base) == (str,):
+            return "string_list", optional
+        mapping = {str: "string", int: "integer", float: "number", bool: "boolean"}
+        key = mapping.get(base)
+        if key is None:
+            raise TypeError(f"unsupported option field type: {tp!r}")
+        return key, optional
+
+    def _parse_value(self, key: str, optional: bool, raw: Any) -> Any:
+        if raw in (None, "") and optional:
+            return None
+        ft = TYPE_REGISTRY[key]
+        to_parse = None if raw in (None, "") else raw
+        if to_parse is not None and not isinstance(to_parse, str):
+            to_parse = ft.adapter.serialize(to_parse)
+        return ft.adapter.parse(to_parse)
+
+    def _format_value(self, key: str, value: Any) -> Any:
+        if value is None:
+            return None
+        ft = TYPE_REGISTRY[key]
+        serialized = ft.adapter.serialize(value)
+        return ft.adapter.parse(serialized) if key == "boolean" else serialized
+
+    # ------------------------------------------------------------------
+    def get_values(self) -> dict[str, Any]:
+        if self._custom is not None:
+            val = self._custom.get_value()
+            return val if isinstance(val, dict) else {}
+        values: dict[str, Any] = {}
+        for name, widget in self._widgets.items():
+            key, optional = self._fields[name]
+            raw = widget.get_value()
+            values[name] = self._parse_value(key, optional, raw)
+        return values
+
+    def set_values(self, values: Mapping[str, Any] | Any | None) -> None:
+        if self._custom is not None:
+            self._custom.set_value({} if values is None else (asdict(values) if is_dataclass(values) else values))
+            return
+        if values is None:
+            values = {}
+        if is_dataclass(values):
+            values = asdict(values)
+        for name, widget in self._widgets.items():
+            key, _ = self._fields[name]
+            widget.set_value(self._format_value(key, values.get(name)))
+
+    def validate(self) -> dict[str, str | None]:
+        if self._custom is not None:
+            # delegate validation to dataclass if available
+            data = self._custom.get_value() or {}
+            errors: dict[str, str | None] = {}
+            if self._option_model is not None:
+                try:
+                    self._option_model(**data)
+                except Exception as exc:  # pragma: no cover - defensive
+                    errors["__all__"] = str(exc)
+                else:
+                    errors["__all__"] = None
+            return errors
+        errors: dict[str, str | None] = {}
+        data: dict[str, Any] = {}
+        for name, widget in self._widgets.items():
+            key, optional = self._fields[name]
+            raw = widget.get_value()
+            try:
+                value = self._parse_value(key, optional, raw)
+            except Exception as exc:
+                widget.set_error(str(exc))
+                errors[name] = str(exc)
+            else:
+                widget.set_error(None)
+                data[name] = value
+                errors[name] = None
+        if errors and any(v is not None for v in errors.values()):
+            return errors
+        if self._option_model is not None:
+            try:
+                self._option_model(**data)
+            except Exception as exc:  # pragma: no cover - defensive
+                errors["__all__"] = str(exc)
+            else:
+                errors["__all__"] = None
+        return errors
+
+
+__all__ = ["OptionsForm"]

--- a/src/pysigil/ui/widgets.py
+++ b/src/pysigil/ui/widgets.py
@@ -101,6 +101,7 @@ TYPE_REGISTRY["string"] = replace(TYPE_REGISTRY["string"], value_widget=_simple_
 TYPE_REGISTRY["integer"] = replace(TYPE_REGISTRY["integer"], value_widget=_simple_entry)
 TYPE_REGISTRY["number"] = replace(TYPE_REGISTRY["number"], value_widget=_simple_entry)
 TYPE_REGISTRY["boolean"] = replace(TYPE_REGISTRY["boolean"], value_widget=_boolean_check)
+TYPE_REGISTRY["string_list"] = replace(TYPE_REGISTRY["string_list"], value_widget=_simple_entry)
 
 
 FIELD_WIDGETS: Dict[str, Callable[[Any], EditorWidget]] = {

--- a/tests/test_options_form.py
+++ b/tests/test_options_form.py
@@ -1,0 +1,96 @@
+from dataclasses import dataclass
+
+import pytest
+
+from pysigil.settings_metadata import FieldType, TYPE_REGISTRY
+from pysigil.ui.options_form import OptionsForm
+
+try:
+    import tkinter as tk
+    from tkinter import ttk
+except Exception:  # pragma: no cover - environment dependent
+    tk = None  # type: ignore
+    ttk = None  # type: ignore
+
+
+@dataclass
+class DemoOptions:
+    text: str
+    count: int
+    ratio: float
+    flag: bool
+    tags: list[str]
+
+
+def _make_form(root):
+    ft = FieldType(TYPE_REGISTRY["string"].adapter, option_model=DemoOptions)
+    return OptionsForm(root, ft)
+
+
+@pytest.mark.skipif(tk is None, reason="tkinter not available")
+def test_basic_get_set_validate():
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+    form = _make_form(root)
+    form.set_values(DemoOptions("hello", 3, 0.5, True, ["a", "b"]))
+    assert form.get_values() == {
+        "text": "hello",
+        "count": 3,
+        "ratio": 0.5,
+        "flag": True,
+        "tags": ["a", "b"],
+    }
+    errs = form.validate()
+    assert all(v is None for v in errs.values())
+    root.destroy()
+
+
+@pytest.mark.skipif(tk is None, reason="tkinter not available")
+def test_validation_errors():
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+    form = _make_form(root)
+    form.set_values({"count": "bad"})
+    errs = form.validate()
+    assert errs["count"]
+    root.destroy()
+
+
+class DummyWidget(ttk.Frame):
+    def __init__(self, master):
+        super().__init__(master)
+        self.entry = ttk.Entry(self)
+        self.entry.pack()
+
+    def get_value(self):
+        v = self.entry.get()
+        return {"value": v} if v else {}
+
+    def set_value(self, value):
+        self.entry.delete(0, tk.END)
+        if value and "value" in value:
+            self.entry.insert(0, value["value"])
+
+    def set_error(self, msg):  # pragma: no cover - placeholder
+        pass
+
+
+def _custom_widget(master):
+    return DummyWidget(master)
+
+
+@pytest.mark.skipif(tk is None, reason="tkinter not available")
+def test_custom_option_widget():
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+    ft = FieldType(TYPE_REGISTRY["string"].adapter, option_widget=_custom_widget)
+    form = OptionsForm(root, ft)
+    form.set_values({"value": "foo"})
+    assert form.get_values()["value"] == "foo"
+    root.destroy()


### PR DESCRIPTION
## Summary
- add OptionsForm helper that builds widgets from FieldType option models and supports custom option widgets
- expose get_values, set_values and validate helpers for Author tools
- centralize option parsing/serialization via FieldType adapters and add string list support

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5eae8e9c0832889cb40c0d82d21ee