### PR TITLE
refactor: rebuild author tools UI

### DIFF
--- a/src/pysigil/ui/author_adapter.py
+++ b/src/pysigil/ui/author_adapter.py
@@ -142,6 +142,15 @@ class AuthorAdapter:
             infos.append(UntrackedInfo(key=key, raw=raw, guessed_type=guessed))
         return infos
 
+    def default_for_key(self, key: str) -> Any | None:
+        """Return the value from the ``default`` scope for *key*."""
+
+        handle = self._require_handle()
+        layers = handle.layers()
+        per_scope = layers.get(key, {})
+        val = per_scope.get("default")
+        return None if val is None else val.value
+
     # ------------------------------------------------------------------
     # Mutations
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace author tools window with a paned layout that lists defined and undiscovered fields with search
- Add dynamic form supporting identity, type, options, defaults and actions with collapsible diff
- Expose default value retrieval through `AuthorAdapter`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5f183a658832883585c193d1955f5