### PR TITLE
Ensure author tools respect field spec options and defaults

### DIFF
--- a/src/pysigil/ui/tk/author_tools.py
+++ b/src/pysigil/ui/tk/author_tools.py
@@ -85,7 +85,12 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         self._tree.item(undis_id, open=True)
 
     # ------------------------------------------------------------------
-    def _build_type_section(self, field_type: FieldType | None, default: object | None = None) -> None:
+    def _build_type_section(
+        self,
+        field_type: FieldType | None,
+        default: object | None = None,
+        options: object | None = None,
+    ) -> None:
         for child in self._opts_frame.winfo_children():
             child.destroy()
         for child in self._default_frame.winfo_children():
@@ -98,9 +103,19 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         if field_type.option_widget is not None:
             self._options_widget = field_type.option_widget(self._opts_frame)
             self._options_widget.pack(fill="x")
+            if options is not None and hasattr(self._options_widget, "set_value"):
+                try:  # best effort
+                    self._options_widget.set_value(options)  # type: ignore[attr-defined]
+                except Exception:
+                    pass
         elif field_type.option_model is not None:
             self._options_widget = OptionsForm(self._opts_frame, field_type)
             self._options_widget.pack(fill="x")
+            if options is not None and hasattr(self._options_widget, "set_values"):
+                try:  # best effort
+                    self._options_widget.set_values(options)
+                except Exception:
+                    pass
         # Default editor
         if field_type.value_widget is not None:
             widget = field_type.value_widget(self._default_frame)  # type: ignore[assignment]
@@ -191,7 +206,7 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         self._default_frame = ttk.LabelFrame(self._form, text="Default")
         self._default_frame.pack(fill="x", pady=(0, 6))
         ft = TYPE_REGISTRY.get(info.type)
-        self._build_type_section(ft, default)
+        self._build_type_section(ft, default, info.options)
 
         # Actions --------------------------------------------------------
         actions = ttk.Frame(self._form)

--- a/tests/test_author_adapter.py
+++ b/tests/test_author_adapter.py
@@ -1,0 +1,25 @@
+from pysigil import authoring
+from pysigil.ui.author_adapter import AuthorAdapter
+import pysigil.api as api
+
+
+def test_upsert_field_sets_options_and_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("SIGIL_APP_NAME", "sigil-test")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("SIGIL_ROOT", str(tmp_path))
+
+    defaults_dir = tmp_path / "pkg" / ".sigil"
+    defaults_dir.mkdir(parents=True)
+    defaults_path = defaults_dir / "settings.ini"
+    defaults_path.write_text("[demo]\n")
+
+    authoring.link("demo", defaults_path)
+    api.register_provider("demo", title="Demo")
+
+    adapter = AuthorAdapter("demo")
+    adapter.upsert_field("alpha", "integer", options={"min": 0}, default=5)
+
+    fields = {f.key: f for f in adapter.list_defined()}
+    assert fields["alpha"].options == {"min": 0}
+    assert adapter.default_for_key("alpha") == 5
+


### PR DESCRIPTION
## Summary
- allow `FieldInfo` and `AuthorAdapter` to carry `options` and write default values
- preload option widgets in author tools and persist defaults when saving
- add regression test for default and options handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5f9eb54908328a857b05e53d68017