### PR TITLE
Parse typed defaults in author tools

### DIFF
--- a/src/pysigil/ui/tk/author_tools.py
+++ b/src/pysigil/ui/tk/author_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 try:  # pragma: no cover - tkinter availability depends on environment
     import tkinter as tk
-    from tkinter import ttk
+    from tkinter import messagebox, ttk
 except Exception:  # pragma: no cover - fallback when tkinter missing
     tk = None  # type: ignore
     ttk = None  # type: ignore
@@ -13,6 +13,7 @@ from ...settings_metadata import TYPE_REGISTRY, FieldType
 from ..author_adapter import AuthorAdapter, FieldInfo
 from ..options_form import OptionsForm
 from ..core import AppCore
+from ..value_parser import parse_field_value
 
 
 class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
@@ -255,6 +256,17 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         default = None
         if self._value_widget is not None and hasattr(self._value_widget, "get_value"):
             default = self._value_widget.get_value()  # type: ignore[attr-defined]
+        if default is not None:
+            try:
+                default = parse_field_value(type_name, default)
+            except (TypeError, ValueError):
+                if messagebox is not None:
+                    if type_name == "boolean":
+                        msg = "Default must be true/false or 1/0"
+                    else:
+                        msg = f"Default must be a {type_name}"
+                    messagebox.showerror("Invalid default", msg, parent=self)
+                return
         # Build kwargs dynamically to match adapter signature
         import inspect
 

--- a/src/pysigil/ui/tk/dialogs.py
+++ b/src/pysigil/ui/tk/dialogs.py
@@ -13,6 +13,7 @@ except Exception:  # pragma: no cover - fallback when tkinter missing
     ttk = None  # type: ignore
 
 from ..provider_adapter import ProviderAdapter, ValueInfo
+from ..value_parser import parse_field_value
 
 
 class EditDialog(tk.Toplevel):  # type: ignore[misc]
@@ -117,22 +118,10 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
 
         raw = self.entries[scope].get()
         type_name = self.adapter.field_info(self.key).type
-        value: object = raw
 
         try:
-            if type_name == "integer":
-                value = int(raw)
-            elif type_name == "number":
-                value = float(raw)
-            elif type_name == "boolean":
-                lower = raw.strip().lower()
-                if lower in {"true", "1"}:
-                    value = True
-                elif lower in {"false", "0"}:
-                    value = False
-                else:
-                    raise ValueError("expected boolean")
-        except ValueError:
+            value = parse_field_value(type_name, raw)
+        except (TypeError, ValueError):
             if messagebox is not None:
                 if type_name == "boolean":
                     msg = "Value must be true/false or 1/0"

--- a/src/pysigil/ui/value_parser.py
+++ b/src/pysigil/ui/value_parser.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from ..settings_metadata import TYPE_REGISTRY
+
+
+def parse_field_value(type_name: str, raw: object) -> object:
+    """Parse *raw* text into a Python value for ``type_name``.
+
+    ``raw`` is typically the content of a text entry widget.  The function
+    accepts ``1``/``0`` for booleans in addition to ``true``/``false`` to mirror
+    the behaviour of the Tk dialogs.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        text = raw.strip()
+        if type_name == "boolean":
+            lower = text.lower()
+            if lower == "1":
+                text = "true"
+            elif lower == "0":
+                text = "false"
+        adapter = TYPE_REGISTRY[type_name].adapter
+        return adapter.parse(text)
+    return raw


### PR DESCRIPTION
## Summary
- add `parse_field_value` helper to convert raw editor text into typed values
- use shared parsing in edit dialog and author tools to validate input before saving
- test parsing of defaults in author mode

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/ui/value_parser.py src/pysigil/ui/tk/dialogs.py src/pysigil/ui/tk/author_tools.py tests/test_author_mode.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fc9d9c048328b05818f2a7bd4401