### PR TITLE
Show "Adopt" button only for undiscovered fields

### DIFF
--- a/src/pysigil/ui/author_adapter.py
+++ b/src/pysigil/ui/author_adapter.py
@@ -208,6 +208,13 @@ class AuthorAdapter:
         handle = self._require_handle()
         handle.delete_field(key, remove_values=remove_values, scopes=tuple(scopes))
 
+    def adopt_untracked(self, mapping: Mapping[str, str]) -> list[FieldInfo]:
+        """Adopt untracked configuration keys as field specifications."""
+
+        handle = self._require_handle()
+        specs = handle.adopt_untracked(mapping)
+        return [FieldInfo(s.key, s.type, s.label, s.description, s.options) for s in specs]
+
     # ------------------------------------------------------------------
     # Validation helpers
     # ------------------------------------------------------------------

--- a/tests/test_author_adapter.py
+++ b/tests/test_author_adapter.py
@@ -23,3 +23,25 @@ def test_upsert_field_sets_options_and_default(tmp_path, monkeypatch):
     assert fields["alpha"].options == {"minimum": 0}
     assert adapter.default_for_key("alpha") == 5
 
+
+def test_adopt_untracked(tmp_path, monkeypatch):
+    monkeypatch.setenv("SIGIL_APP_NAME", "sigil-test")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("SIGIL_ROOT", str(tmp_path))
+
+    defaults_dir = tmp_path / "pkg" / ".sigil"
+    defaults_dir.mkdir(parents=True)
+    defaults_path = defaults_dir / "settings.ini"
+    defaults_path.write_text("[demo]\nfoo = bar\n")
+
+    authoring.link("demo", defaults_path)
+    api.register_provider("demo", title="Demo")
+
+    adapter = AuthorAdapter("demo")
+    assert any(u.key == "foo" for u in adapter.list_undiscovered())
+
+    adapter.adopt_untracked({"foo": "string"})
+    defined = {f.key for f in adapter.list_defined()}
+    assert "foo" in defined
+    assert not any(u.key == "foo" for u in adapter.list_undiscovered())
+


### PR DESCRIPTION
## Summary
- Only render the Author Tools "Adopt" action when selecting an undiscovered key
- Implement adoption by calling `AuthorAdapter.adopt_untracked`
- Add adapter method and unit test for adopting untracked fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b608bf7e888328a576a26a185f0617