### PR TITLE
Use POSIX path for project variable

### DIFF
--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -218,7 +218,7 @@ class App:
                 proj_path = self.adapter.target_path("project")
             except Exception:
                 proj_path = ""
-            self._project_var.set(str(proj_path))
+            self._project_var.set(proj_path.as_posix())
 
     def on_pill_click(self, key: str, scope: str) -> None:
         self._open_edit_dialog(key, scope)


### PR DESCRIPTION
## Summary
- Normalize project path in Tk UI to use forward slashes

## Testing
- `pre-commit run --files src/pysigil/ui/tk/__init__.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b60fd101c08328bca0023e14174d43