### PR TITLE
Launch author GUI via CLI

### DIFF
--- a/AUTHORS_GUIDE.md
+++ b/AUTHORS_GUIDE.md
@@ -74,7 +74,7 @@ sigil author unlink-defaults my-package
 Launch the GUI wizard:
 
 ```bash
-sigil setup
+sigil gui --author
 ```
 
 Steps:

--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ A confirmation dialog appears and the folder opens (e.g.
 Package authors can register development defaults via:
 
 ```bash
-sigil setup
+sigil gui --author
 ```
 
 Or launch it programmatically:
 
 ```python
-from pysigil.ui.tk import launch
+from pysigil.ui.tk.author import main as launch_author
 
-launch()
+launch_author()
 ```

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -14,7 +14,7 @@ host = localhost
 port = 5432
 ``` | Becomes the base layer of the preference chain. |
 | 2 | Register the package during development | ```bash
-sigil author register --auto  # or `sigil setup`
+sigil author register --auto  # or `sigil gui --author`
 ``` | Dev links let Sigil find your defaults without installing the package. |
 | 3 | Ship settings and metadata files | ```toml
 # pyproject.toml

--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -206,14 +206,12 @@ def export_cmd(args: argparse.Namespace) -> int:
 
 
 def gui_cmd(args: argparse.Namespace) -> int:  # pragma: no cover - GUI interactions
-    launch_gui(initial_provider=args.app, author_mode=author_mode_enabled(args))
-    return 0
+    if author_mode_enabled(args):
+        from .ui.tk.author import main as author_main
 
-
-def setup_cmd(_: argparse.Namespace) -> int:  # pragma: no cover - GUI interactions
-    from .ui.tk.author import main as author_main
-
-    author_main()
+        author_main()
+    else:
+        launch_gui(initial_provider=args.app, author_mode=False)
     return 0
 
 
@@ -421,10 +419,6 @@ def build_parser() -> argparse.ArgumentParser:
     p_gui.add_argument("--include-sigil", action="store_true")
     p_gui.add_argument("--no-remember", action="store_true")
     p_gui.set_defaults(func=gui_cmd)
-
-    # setup command
-    p_setup = subparsers.add_parser("setup", help="Launch the defaults registration GUI.")
-    p_setup.set_defaults(func=setup_cmd)
 
     # author group
     p_author = subparsers.add_parser("author", help="Package author helpers.")


### PR DESCRIPTION
## Summary
- launch author registration GUI when `sigil gui --author` is used
- drop dedicated `setup` subcommand
- update documentation to reference the new author GUI entry point

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6137b0f3c83289e29038d5fcef225