### PR TITLE
feat: add author GUI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Package authors can register development defaults via:
 sigil setup
 ```
 
+Launch authoring tools without the editor:
+
+```bash
+sigil author
+```
+
 Or launch it programmatically:
 
 ```python

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -30,6 +30,12 @@ get_pref = _sigil.get_pref
 set_pref = _sigil.set_pref
 ``` | • One-line access:<br>`get_pref("db.host")`<br>• Handles env ▶ project ▶ user ▶ defaults without extra code. |
 
+Launch authoring tools without starting the main editor:
+
+```bash
+sigil author
+```
+
 ## What you get immediately
 
 Fully merged prefs:

--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -210,6 +210,15 @@ def gui_cmd(args: argparse.Namespace) -> int:  # pragma: no cover - GUI interact
     return 0
 
 
+def author_gui_cmd(_: argparse.Namespace) -> int:  # pragma: no cover - GUI interactions
+    from .ui.tk import App
+
+    app = App(author_mode=True, initial_provider="sigil-dummy")
+    app._open_author_tools()
+    app.root.mainloop()
+    return 0
+
+
 def setup_cmd(_: argparse.Namespace) -> int:  # pragma: no cover - GUI interactions
     from .ui.tk.author import main as author_main
 
@@ -426,9 +435,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_setup = subparsers.add_parser("setup", help="Launch the defaults registration GUI.")
     p_setup.set_defaults(func=setup_cmd)
 
-    # author group
-    p_author = subparsers.add_parser("author", help="Package author helpers.")
-    sp_author = p_author.add_subparsers(dest="author_cmd", required=True)
+    # author command / group
+    p_author = subparsers.add_parser(
+        "author", help="Launch the author tools GUI or manage development links."
+    )
+    p_author.set_defaults(func=author_gui_cmd)
+    sp_author = p_author.add_subparsers(dest="author_cmd")
 
     p_reg = sp_author.add_parser("register", help="Register package defaults for development.")
     p_reg.add_argument("--package-dir", type=Path, help="Package directory")


### PR DESCRIPTION
## Summary
- keep `sigil setup` for defaults registration and add separate `sigil author` CLI to open authoring tools
- document the new `sigil author` command in README and integration guide

## Testing
- `pre-commit run --files src/pysigil/cli.py README.md docs/integration.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit (proxy 403))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b616f837dc8328bd0d8c524d706139