### PR TITLE
Launch standalone author tools

### DIFF
--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -211,11 +211,30 @@ def gui_cmd(args: argparse.Namespace) -> int:  # pragma: no cover - GUI interact
 
 
 def author_gui_cmd(_: argparse.Namespace) -> int:  # pragma: no cover - GUI interactions
-    from .ui.tk import App
+    import sys
+    from .ui.core import AppCore
+    from .ui.tk.author_tools import AuthorTools
+    import tkinter as tk
 
-    app = App(author_mode=True, initial_provider="sigil-dummy")
-    app._open_author_tools()
-    app.root.mainloop()
+    try:
+        proj_root = find_project_root()
+    except ProjectRootNotFoundError:
+        proj_root = Path.cwd()
+    dist_name = read_dist_name_from_pyproject(proj_root)
+    pkg = find_package_dir(proj_root, dist_name)
+    if not pkg:
+        print("Could not auto-detect package directory", file=sys.stderr)
+        return 2
+    provider_id = default_provider_id(pkg, dist_name)
+
+    core = AppCore(author_mode=True)
+    core.select_provider(provider_id).result()
+
+    root = tk.Tk()
+    root.withdraw()
+    tools = AuthorTools(root, core)
+    tools.protocol("WM_DELETE_WINDOW", root.destroy)
+    root.mainloop()
     return 0
 
 

--- a/src/pysigil/ui/tk/author_tools.py
+++ b/src/pysigil/ui/tk/author_tools.py
@@ -21,10 +21,21 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
 
     def __init__(self, master: tk.Misc, core: AppCore) -> None:
         super().__init__(master)
-        self.title("Sigil – Author Tools")
+        pid = core.state.provider_id or ""
+        project = str(core.state.project_root) if core.state.project_root else ""
+        title = "Sigil – Author Tools"
+        if pid:
+            title += f" – {pid}"
+        if project:
+            title += f" – {project}"
+        self.title(title)
         self.core = core
-        pid = core.state.provider_id or None
-        self.adapter = AuthorAdapter(pid)
+        self._info_var = tk.StringVar()
+        info = f"Provider: {pid}"
+        if project:
+            info += f" – {project}"
+        self._info_var.set(info)
+        self.adapter = AuthorAdapter(pid or None)
         self._current_key: str | None = None
         self._value_widget: object | None = None
         self._options_widget: object | None = None
@@ -39,6 +50,7 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
     # ------------------------------------------------------------------
     def _build(self) -> None:
         self.geometry("800x600")
+        ttk.Label(self, textvariable=self._info_var).pack(anchor="w", padx=6, pady=6)
         pw = ttk.PanedWindow(self, orient="horizontal")
         self._left = ttk.Frame(pw)
         self._right = ttk.Frame(pw)


### PR DESCRIPTION
## Summary
- Launch author tools without opening the main settings window when running `sigil author`
- Show provider and project path in author tools title and header for context

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc6e9cb4dc832895dd985a46ad4ec1