### PR TITLE
Launch standalone author tools

### DIFF
--- a/src/pysigil/ui/tk/author_tools.py
+++ b/src/pysigil/ui/tk/author_tools.py
@@ -21,10 +21,21 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
 
     def __init__(self, master: tk.Misc, core: AppCore) -> None:
         super().__init__(master)
-        self.title("Sigil – Author Tools")
+        pid = core.state.provider_id or ""
+        project = str(core.state.project_root) if core.state.project_root else ""
+        title = "Sigil – Author Tools"
+        if pid:
+            title += f" – {pid}"
+        if project:
+            title += f" – {project}"
+        self.title(title)
         self.core = core
-        pid = core.state.provider_id or None
-        self.adapter = AuthorAdapter(pid)
+        self._info_var = tk.StringVar()
+        info = f"Provider: {pid}"
+        if project:
+            info += f" – {project}"
+        self._info_var.set(info)
+        self.adapter = AuthorAdapter(pid or None)
         self._current_key: str | None = None
         self._value_widget: object | None = None
         self._options_widget: object | None = None
@@ -39,6 +50,7 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
     # ------------------------------------------------------------------
     def _build(self) -> None:
         self.geometry("800x600")
+        ttk.Label(self, textvariable=self._info_var).pack(anchor="w", padx=6, pady=6)
         pw = ttk.PanedWindow(self, orient="horizontal")
         self._left = ttk.Frame(pw)
         self._right = ttk.Frame(pw)

--- a/tests/manual/manual_author_gui.py
+++ b/tests/manual/manual_author_gui.py
@@ -4,9 +4,16 @@ Undiscovered provider fields are collapsed at the bottom of the tree.
 Expand the "Undiscovered" node to load and manage them when testing.
 """
 
-from pysigil.ui.tk import App
+import tkinter as tk
+
+from pysigil.ui.core import AppCore
+from pysigil.ui.tk.author_tools import AuthorTools
+
 
 if __name__ == "__main__":  # pragma: no cover - manual only
-    app = App(author_mode=True, initial_provider="sigil-dummy")
-    app._open_author_tools()
-    app.root.mainloop()
+    core = AppCore(author_mode=True)
+    core.select_provider("sigil-dummy").result()
+    root = tk.Tk()
+    root.withdraw()
+    AuthorTools(root, core)
+    root.mainloop()


### PR DESCRIPTION
## Summary
- Launch author tools without opening the main settings window when running `sigil author`
- Show provider and project path in author tools title and header for context
- Gracefully handle unknown providers in `sigil author` and update manual launch helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc6e9cb4dc832895dd985a46ad4ec1