### PR TITLE
Add Sigil toolkit helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ python -m pysigil --help
 ```
 
 ```python
-from pysigil.core import Sigil
+from pysigil import helpers_for
 
-sigil = Sigil("pysigil")
-get_pref = sigil.get_pref
-set_pref = sigil.set_pref
+get_setting, set_setting = helpers_for("pysigil")
+get_setting("ui.color")
+set_setting("ui.color", "blue")
 ```
 
 Once installed, try a few commands:

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -23,12 +23,11 @@ sigil author register --auto  # or `sigil setup`
 ``` | Installed distributions are scanned for these files—no Python entry points needed. |
 | 4 | (Optional) Expose helpers so callers never touch pysigil APIs | ```python
 # mypkg/__init__.py
-from pysigil.core import Sigil
+from pysigil import helpers_for
 
-_sigil = Sigil(__name__)  # __name__ == "mypkg"
-get_pref = _sigil.get_pref
-set_pref = _sigil.set_pref
-``` | • One-line access:<br>`get_pref("db.host")`<br>• Handles env ▶ project ▶ user ▶ defaults without extra code. |
+get_setting, set_setting = helpers_for(__name__)
+__all__ = ["get_setting", "set_setting"]
+``` | • One-line access:<br>`get_setting("db.host")`<br>• Handles env ▶ project ▶ user ▶ defaults without extra code. |
 
 Launch authoring tools without starting the main editor:
 
@@ -41,7 +40,7 @@ sigil author
 Fully merged prefs:
 `SIGIL_MYPKG_DB_HOST (env) → ./settings.ini (project) → ~/.config/mypkg/settings.ini (user) → your defaults.ini.`
 
-No boiler-plate: call `get_pref()` / `set_pref()` from anywhere in your code.
+No boiler-plate: call `get_setting()` / `set_setting()` from anywhere in your code.
 
 User tooling already works:
 

--- a/src/pysigil/__init__.py
+++ b/src/pysigil/__init__.py
@@ -1,5 +1,12 @@
 from .core import Sigil, SigilError
 from .merge_policy import parse_key
 from .policy import policy
+from .toolkit import helpers_for
 
-__all__ = ["Sigil", "SigilError", "parse_key", "policy"]
+__all__ = [
+    "Sigil",
+    "SigilError",
+    "parse_key",
+    "policy",
+    "helpers_for",
+]

--- a/src/pysigil/toolkit.py
+++ b/src/pysigil/toolkit.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .core import Sigil
+
+__all__ = ["helpers_for"]
+
+
+def helpers_for(app_name: str) -> tuple[Callable[..., Any], Callable[..., None]]:
+    """Return setting helpers bound to *app_name*.
+
+    The returned ``get_setting`` and ``set_setting`` functions operate on a
+    dedicated :class:`Sigil` instance for the provided application name.
+    """
+
+    sigil = Sigil(app_name)
+
+    def get_setting(
+        key: str,
+        *,
+        cast: Callable[[str], Any] | None = None,
+        default: Any | None = None,
+    ) -> Any:
+        return sigil.get_pref(key, cast=cast, default=default)
+
+    def set_setting(
+        key: str,
+        value: Any,
+        *,
+        scope: str | None = None,
+    ) -> None:
+        sigil.set_pref(key, value, scope=scope)
+
+    return get_setting, set_setting

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pysigil import helpers_for
+
+
+def test_helpers_for_isolated_apps(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+    get_a, set_a = helpers_for("demo")
+    set_a("section.value", "1")
+    assert get_a("section.value", cast=int) == 1
+
+    get_b, set_b = helpers_for("other")
+    assert get_b("section.value") is None
+    set_b("section.value", "2")
+    assert get_b("section.value", cast=int) == 2
+
+    # original demo settings remain unchanged
+    assert get_a("section.value", cast=int) == 1


### PR DESCRIPTION
## Summary
- provide `helpers_for` factory to generate app-scoped `get_setting`/`set_setting`
- re-export `helpers_for` from the package root
- document helper usage in README and integration guide
- test that helpers for different apps operate independently

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/toolkit.py src/pysigil/__init__.py docs/integration.md README.md tests/test_toolkit.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc772869988328917f565c4d91265c