### PR TITLE
feat(author): add dev-link-first authoring entrypoint

### DIFF
--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -26,7 +26,7 @@ from .config import (
 )
 from .core import Sigil
 from .discovery import pep503_name
-from .ui.tk import launch as launch_gui
+from .errors import DevLinkNotFoundError
 from .paths import (
     default_config_dir,
     default_data_dir,
@@ -45,8 +45,7 @@ from .resolver import (
     read_dist_name_from_pyproject,
 )
 from .root import ProjectRootNotFoundError, find_project_root
-from .errors import DevLinkNotFound, UnknownProviderError
-
+from .ui.tk import launch as launch_gui
 
 AUTHOR_FLAG_ENV = "SIGIL_AUTHOR"
 
@@ -217,6 +216,7 @@ def launch_author_ui(_ctx: object) -> int:  # pragma: no cover - GUI interaction
 
 def author_gui_cmd(_: argparse.Namespace) -> int:  # pragma: no cover - GUI interactions
     import sys
+
     from .ui.core import AppCore
 
     try:
@@ -234,7 +234,7 @@ def author_gui_cmd(_: argparse.Namespace) -> int:  # pragma: no cover - GUI inte
     pid = normalize_provider_id(provider_id)
     try:
         ctx = core.orchestrator.load_author_context(pid)
-    except DevLinkNotFound:
+    except DevLinkNotFoundError:
         err = (
             f"No development link for '{pid}'.\n"
             f"Create one:\n  sigil link --dev /path/to/pkg --provider {pid}"

--- a/src/pysigil/errors.py
+++ b/src/pysigil/errors.py
@@ -30,6 +30,10 @@ class UnknownProviderError(SigilError):
     """Raised when a provider is not registered."""
 
 
+class DevLinkNotFound(SigilError):
+    """Raised when a development link is missing."""
+
+
 class DuplicateProviderError(SigilError):
     """Raised when attempting to create a provider that already exists."""
 

--- a/src/pysigil/errors.py
+++ b/src/pysigil/errors.py
@@ -30,7 +30,7 @@ class UnknownProviderError(SigilError):
     """Raised when a provider is not registered."""
 
 
-class DevLinkNotFound(SigilError):
+class DevLinkNotFoundError(SigilError):
     """Raised when a development link is missing."""
 
 

--- a/src/pysigil/orchestrator.py
+++ b/src/pysigil/orchestrator.py
@@ -10,19 +10,20 @@ the accompanying user request so that it can grow organically.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Literal, Mapping
+from typing import Literal
 
 from .authoring import get as _get_dev_link, normalize_provider_id
 from .errors import (
+    DevLinkNotFoundError,
     DuplicateFieldError,
     PolicyError,
     SigilLoadError,
     UnknownFieldError,
     UnknownProviderError,
     ValidationError,
-    DevLinkNotFound,
 )
 from .root import ProjectRootNotFoundError
 from .settings_metadata import (
@@ -75,7 +76,7 @@ class Orchestrator:
         pid = normalize_provider_id(provider_id)
         dl = _get_dev_link(pid)
         if dl is None:
-            raise DevLinkNotFound(pid)
+            raise DevLinkNotFoundError(pid)
         return dl.defaults_path.parent.parent
 
     def spec_exists(self, provider_id: str) -> bool:
@@ -86,7 +87,7 @@ class Orchestrator:
         pid = normalize_provider_id(provider_id)
         dl = _get_dev_link(pid)
         if dl is None:
-            raise DevLinkNotFound(pid)
+            raise DevLinkNotFoundError(pid)
         dev_root = dl.defaults_path.parent.parent
         if self.spec_backend.exists(pid):
             spec = self.spec_backend.get_spec(pid)

--- a/src/pysigil/ui/core.py
+++ b/src/pysigil/ui/core.py
@@ -261,6 +261,7 @@ class AppCore:
         self.state = AppState(author_mode=author_mode)
         self.service = service or ProvidersService(author_mode=author_mode)
         self.events = EventBus()
+        self.orchestrator = api._ORCH
         self._executor = executor or ThreadPoolExecutor(max_workers=4)
         self._lock = threading.Lock()
 

--- a/tests/test_author_entrypoint.py
+++ b/tests/test_author_entrypoint.py
@@ -1,10 +1,11 @@
 import types
-import pytest
 from pathlib import Path
 
-from pysigil.orchestrator import Orchestrator
+import pytest
+
 import pysigil.orchestrator as orch_mod
-from pysigil.errors import DevLinkNotFound
+from pysigil.errors import DevLinkNotFoundError
+from pysigil.orchestrator import Orchestrator
 from pysigil.settings_metadata import InMemorySpecBackend, ProviderSpec
 
 
@@ -62,7 +63,7 @@ def test_author_edit_with_spec(monkeypatch, tmp_path):
 def test_author_no_devlink(monkeypatch):
     monkeypatch.setattr(orch_mod, "_get_dev_link", lambda pid: None)
     orch = Orchestrator(spec_backend=InMemorySpecBackend())
-    with pytest.raises(DevLinkNotFound):
+    with pytest.raises(DevLinkNotFoundError):
         orch.load_author_context("foo")
 
 

--- a/tests/test_author_entrypoint.py
+++ b/tests/test_author_entrypoint.py
@@ -1,0 +1,79 @@
+import types
+import pytest
+from pathlib import Path
+
+from pysigil.orchestrator import Orchestrator
+import pysigil.orchestrator as orch_mod
+from pysigil.errors import DevLinkNotFound
+from pysigil.settings_metadata import InMemorySpecBackend, ProviderSpec
+
+
+def make_dev_link(tmp_path: Path) -> Path:
+    pkg = tmp_path / "pkg" / ".sigil"
+    pkg.mkdir(parents=True)
+    defaults = pkg / "settings.ini"
+    defaults.write_text("")
+    return defaults
+
+
+def test_author_bootstrap_no_spec(monkeypatch, tmp_path):
+    defaults = make_dev_link(tmp_path)
+    monkeypatch.setattr(orch_mod, "_get_dev_link", lambda pid: types.SimpleNamespace(defaults_path=defaults))
+
+    spec_backend = InMemorySpecBackend()
+    orch = Orchestrator(spec_backend=spec_backend)
+
+    def boom(pid):
+        raise AssertionError("get_spec should not be called")
+
+    monkeypatch.setattr(spec_backend, "get_spec", boom)
+
+    ctx = orch.load_author_context("Example-Prov")
+    assert ctx.mode == "bootstrap"
+    assert ctx.spec is None
+    assert ctx.provider_id == "example-prov"
+    assert ctx.dev_root == defaults.parent.parent
+
+
+def test_author_edit_with_spec(monkeypatch, tmp_path):
+    defaults = make_dev_link(tmp_path)
+    monkeypatch.setattr(orch_mod, "_get_dev_link", lambda pid: types.SimpleNamespace(defaults_path=defaults))
+
+    spec_backend = InMemorySpecBackend()
+    spec = ProviderSpec(provider_id="example", schema_version="0", title=None, description=None, fields=())
+    spec_backend._specs["example"] = spec
+    spec_backend._etags["example"] = "e"
+    orch = Orchestrator(spec_backend=spec_backend)
+
+    calls = []
+
+    def wrapped(pid):
+        calls.append(pid)
+        return spec_backend._specs[pid]
+
+    monkeypatch.setattr(spec_backend, "get_spec", wrapped)
+
+    ctx = orch.load_author_context("example")
+    assert ctx.mode == "edit"
+    assert ctx.spec is spec
+    assert calls == ["example"]
+
+
+def test_author_no_devlink(monkeypatch):
+    monkeypatch.setattr(orch_mod, "_get_dev_link", lambda pid: None)
+    orch = Orchestrator(spec_backend=InMemorySpecBackend())
+    with pytest.raises(DevLinkNotFound):
+        orch.load_author_context("foo")
+
+
+def test_normalization_consistency(monkeypatch, tmp_path):
+    defaults = make_dev_link(tmp_path)
+    links = {"foo-bar": types.SimpleNamespace(defaults_path=defaults)}
+
+    def fake_get(pid):
+        return links.get(pid)
+
+    monkeypatch.setattr(orch_mod, "_get_dev_link", fake_get)
+    orch = Orchestrator(spec_backend=InMemorySpecBackend())
+    ctx = orch.load_author_context("Foo.Bar")
+    assert ctx.provider_id == "foo-bar"


### PR DESCRIPTION
## Summary
- add `AuthorContext` and `load_author_context` to orchestrator for dev-link-first authoring
- check spec existence without loading via new backend `exists` API
- surface `DevLinkNotFound` and update CLI author command
- cover authoring bootstrap and edit modes with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc90a485448328925a5f0a1eaef2b4