### PR TITLE
Fix scope pill ordering after editing

### DIFF
--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -94,6 +94,13 @@ class FieldRow(ttk.Frame):
 
         values: Dict[str, ValueInfo] = self.adapter.values_for_key(self.key)
         scopes = self.adapter.scopes()
+
+        # Ensure pills are packed in the same order as ``scopes`` by first
+        # unpacking any existing widgets.  Without this, newly created scopes
+        # would always be appended to the end regardless of the desired order.
+        for child in self.pills.pack_slaves():
+            child.pack_forget()
+
         for scope in scopes:
             has_value = scope in values
             def value_provider(s=scope) -> Any:


### PR DESCRIPTION
## Summary
- ensure scope pills are repacked so new scopes appear in display order

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/ui/tk/rows.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9a78f1a883288605bed09895a3d7