### PR TITLE
Align Tk field columns and show labels

### DIFF
--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -99,6 +99,7 @@ class App:
         self._align_pending = False
         self._key_col_width: int | None = None
         self._pill_col_width: int | None = None
+        self._eff_col_width: int | None = None
         self._author_tools: tk.Toplevel | None = None
 
         self.root.title("pysigil")
@@ -146,13 +147,13 @@ class App:
         self._table.pack(fill="both", expand=True, padx=6, pady=6)
 
         style = ttk.Style(self.root)
-        style.configure("Title.TLabel", font=(None, 10, "bold"), anchor="center")
+        style.configure("Title.TLabel", font=(None, 10, "bold"))
 
         header = ttk.Frame(self._table)
         header.pack(fill="x")
-        ttk.Label(header, text="Key", style="Title.TLabel").grid(row=0, column=0, sticky="ew")
-        ttk.Label(header, text="Value (effective)", style="Title.TLabel").grid(row=0, column=1, sticky="ew")
-        ttk.Label(header, text="Scopes", style="Title.TLabel").grid(row=0, column=2, sticky="ew")
+        ttk.Label(header, text="Key", style="Title.TLabel", anchor="w").grid(row=0, column=0, sticky="ew")
+        ttk.Label(header, text="Value (effective)", style="Title.TLabel", anchor="w").grid(row=0, column=1, sticky="ew")
+        ttk.Label(header, text="Scopes", style="Title.TLabel", anchor="w").grid(row=0, column=2, sticky="ew")
         header.columnconfigure(1, weight=1)
 
         self._rows_container = ttk.Frame(self._table)
@@ -333,6 +334,7 @@ class App:
         self.root.update_idletasks()
         key_w = max(r.lbl_key.winfo_reqwidth() for r in self.field_rows.values())
         pills_w = max(r.pills.winfo_reqwidth() for r in self.field_rows.values())
+        eff_w = max(r.lbl_eff.winfo_reqwidth() for r in self.field_rows.values())
         if key_w != self._key_col_width:
             for r in self.field_rows.values():
                 r.grid_columnconfigure(0, minsize=key_w)
@@ -341,6 +343,10 @@ class App:
             for r in self.field_rows.values():
                 r.grid_columnconfigure(2, minsize=pills_w)
             self._pill_col_width = pills_w
+        if eff_w != self._eff_col_width:
+            for r in self.field_rows.values():
+                r.grid_columnconfigure(1, minsize=eff_w)
+            self._eff_col_width = eff_w
 
 
 def launch(initial_provider: str | None = None, *, author_mode: bool = False) -> None:

--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -47,19 +47,25 @@ class FieldRow(ttk.Frame):
         # container for key + info button
         self.key_frame = ttk.Frame(self)
         self.key_frame.grid(row=0, column=0, sticky="w")
-        self.lbl_key = ttk.Label(self.key_frame, text=key)
-        self.lbl_key.pack(side="left")
-        self.info_btn: tk.Label | None = None
-        self.lbl_desc: ttk.Label | None = None
         info = None
         if hasattr(adapter, "field_info"):
             try:
                 info = adapter.field_info(key)  # type: ignore[attr-defined]
             except Exception:
                 info = None
+        label = getattr(info, "label", None) or key
+        self.lbl_key = ttk.Label(self.key_frame, text=label)
+        self.lbl_key.pack(side="left")
+        self.info_btn: tk.Label | None = None
+        self.lbl_desc: ttk.Label | None = None
         if info:
-            tip = info.description or info.description_short
-            if tip:
+            desc = info.description or info.description_short
+            tip_lines = []
+            if desc:
+                tip_lines.append(desc)
+            tip_lines.append(f"Key: {key}")
+            tip = "\n\n".join(tip_lines)
+            if desc or key:
                 self.info_btn = tk.Label(
                     self.key_frame,
                     text="\u24D8",
@@ -69,6 +75,7 @@ class FieldRow(ttk.Frame):
                 )
                 self.info_btn.pack(side="left", padx=(4, 0))
                 HoverTip(self.info_btn, lambda: tip)
+                HoverTip(self.lbl_key, lambda: tip)
             if info.description_short:
                 self.lbl_desc = ttk.Label(
                     self,
@@ -89,6 +96,7 @@ class FieldRow(ttk.Frame):
             relief="ridge",
             padx=10,
             pady=6,
+            anchor="w",
         )
         self.lbl_eff.grid(row=0, column=1, sticky="ew", padx=(8, 8))
 
@@ -245,7 +253,17 @@ class FieldRow(ttk.Frame):
         """Update field key label based on new metadata."""
         key = getattr(info, "key", self.key)
         self.key = key
-        self.lbl_key.configure(text=key)
+        label = getattr(info, "label", None) or key
+        self.lbl_key.configure(text=label)
+        desc = getattr(info, "description", None) or getattr(info, "description_short", None)
+        tip_lines = []
+        if desc:
+            tip_lines.append(desc)
+        tip_lines.append(f"Key: {key}")
+        tip = "\n\n".join(tip_lines)
+        if self.info_btn is not None:
+            HoverTip(self.info_btn, lambda: tip)
+        HoverTip(self.lbl_key, lambda: tip)
 
 
 __all__ = ["FieldRow"]


### PR DESCRIPTION
## Summary
- left align header titles and effective value cells
- size key, value, and scope columns consistently
- display field labels and show key/description in tooltip

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c594e9e5b883288e065ef37f6e7e01