### PR TITLE
Fix debug column overlay to respect environment variable at runtime

### DIFF
--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -24,7 +24,10 @@ _SCOPE_COLORS = {
     "default": SCOPE_COLOR["Def"],
 }
 
-_DEBUG_COLUMNS = bool(os.environ.get("PYSGIL_DEBUG_COLUMNS"))
+
+def _debug_columns() -> bool:
+    """Return True when the debug column overlay is enabled."""
+    return bool(os.environ.get("PYSGIL_DEBUG_COLUMNS"))
 
 
 class FieldRow(ttk.Frame):
@@ -128,7 +131,7 @@ class FieldRow(ttk.Frame):
 
         self.refresh()
 
-        if _DEBUG_COLUMNS and tk is not None:
+        if _debug_columns() and tk is not None:
             self._debug_canvas = tk.Canvas(self, highlightthickness=0)
             self._debug_canvas.place(relx=0, rely=0, relwidth=1, relheight=1)
             self.bind("<Configure>", self._on_debug_configure)
@@ -182,7 +185,7 @@ class FieldRow(ttk.Frame):
             )
 
     def _on_debug_configure(self, event: tk.Event) -> None:
-        if not _DEBUG_COLUMNS:
+        if not _debug_columns():
             return
         canvas = getattr(self, "_debug_canvas", None)
         if canvas is None:

--- a/tests/test_field_row.py
+++ b/tests/test_field_row.py
@@ -1,3 +1,4 @@
+import importlib
 import pytest
 import types
 
@@ -188,5 +189,22 @@ def test_field_row_default_effective():
     assert pill.state == "effective"
     assert pill.color == "#000000"
     assert pill.locked
+    root.destroy()
+
+
+def test_debug_columns_env_var_after_import(monkeypatch):
+    if tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = tk.Tk()
+    except Exception:
+        pytest.skip("no display available")
+
+    monkeypatch.delenv("PYSGIL_DEBUG_COLUMNS", raising=False)
+    importlib.reload(tk_rows)
+
+    monkeypatch.setenv("PYSGIL_DEBUG_COLUMNS", "1")
+    row = tk_rows.FieldRow(root, DummyAdapter(), "alpha", lambda k, s: None, compact=False)
+    assert hasattr(row, "_debug_canvas")
     root.destroy()
 


### PR DESCRIPTION
## Summary
- check `PYSGIL_DEBUG_COLUMNS` dynamically instead of at import time
- add regression test for debug column overlay

## Testing
- `pre-commit run --files src/pysigil/ui/tk/rows.py tests/test_field_row.py` *(failed: command not found)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5a3cb66a8832889c556d50c9ce212