### PR TITLE
Align key column across field rows

### DIFF
--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -332,7 +332,7 @@ class App:
         if not self.field_rows:
             return
         self.root.update_idletasks()
-        key_w = max(r.lbl_key.winfo_reqwidth() for r in self.field_rows.values())
+        key_w = max(r.key_frame.winfo_reqwidth() for r in self.field_rows.values())
         pills_w = max(r.pills.winfo_reqwidth() for r in self.field_rows.values())
         eff_w = max(r.lbl_eff.winfo_reqwidth() for r in self.field_rows.values())
         if key_w != self._key_col_width:


### PR DESCRIPTION
## Summary
- ensure key column widths include optional info button so FieldRows align

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5a591abec832895190c0518d423d5