### PR TITLE
Fix Tkinter highlight configuration for field rows

### DIFF
--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -209,13 +209,23 @@ class App:
         self._hdr_edit.grid(row=0, column=3, sticky="ew")
         self._header.columnconfigure(1, weight=1)
 
-        self._rows_container = ttk.Frame(self._table, style="CardFrame.TFrame")
+        self._rows_container = tk.Frame(
+            self._table,
+            bg=palette["card"],
+            highlightthickness=1,
+            highlightbackground=palette["card_edge"],
+            highlightcolor=palette["card_edge"],
+        )
         self._rows_container.pack(fill="both", expand=True)
-        self._rows_container.configure(highlightthickness=1, highlightbackground=palette["card_edge"], highlightcolor=palette["card_edge"])
 
     def _style_row(self, row: FieldRow) -> None:
         palette = self.palette
-        row.configure(style="CardFrame.TFrame", highlightthickness=1, highlightbackground=palette["card_edge"], highlightcolor=palette["card_edge"])
+        row.configure(
+            bg=palette["card"],
+            highlightthickness=1,
+            highlightbackground=palette["card_edge"],
+            highlightcolor=palette["card_edge"],
+        )
         row.key_frame.configure(style="CardFrame.TFrame")
         row.lbl_key.configure(background=palette["card"], foreground=palette["ink"])
         if row.info_btn:

--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -31,7 +31,7 @@ def _debug_columns() -> bool:
     return bool(os.environ.get("PYSGIL_DEBUG_COLUMNS"))
 
 
-class FieldRow(ttk.Frame):
+class FieldRow(tk.Frame):
     """Representation of a single field row with scope pills."""
 
     def __init__(


### PR DESCRIPTION
## Summary
- replace ttk frames with tk frames for row container and field rows to allow highlight styling
- style rows with background and highlight colors from palette

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5b8d915e48328b4b46e3c8e3d11f8