### PR TITLE
feat: adopt dark aurelia theme

### DIFF
--- a/src/pysigil/ui/aurelia_theme.py
+++ b/src/pysigil/ui/aurelia_theme.py
@@ -19,33 +19,22 @@ except Exception:  # pragma: no cover - fallback when tkinter missing
 # Palette
 # ---------------------------------------------------------------------------
 
-_AURELIA_PALETTE: dict[str, dict[str, str]] = {
-    # Neutrals ---------------------------------------------------------------
-    "neutrals": {
-        "0": "#ffffff",
-        "50": "#f9fafb",
-        "100": "#f3f4f6",
-        "200": "#e5e7eb",
-        "300": "#d1d5db",
-        "400": "#9ca3af",
-        "500": "#6b7280",
-        "600": "#475569",
-        "700": "#374151",
-        "800": "#1f2937",
-        "900": "#111827",
-    },
-    # Text colours ----------------------------------------------------------
-    "text": {
-        "fg": "#111827",
-        "muted": "#6b7280",
-        "on_primary": "#ffffff",
-    },
-    # Accent colours --------------------------------------------------------
-    "accents": {
-        "primary": "#1e40af",
-        "primary_hover": "#1d4ed8",
-    },
-    # Scope colours ---------------------------------------------------------
+_AURELIA_PALETTE: dict[str, object] = {
+    "bg": "#2B313B",
+    "card": "#EEF3FA",
+    "card_edge": "#D4DEEE",
+    "hdr_fg": "#F4F8FF",
+    "hdr_muted": "#C3CFE4",
+    "ink": "#0E1724",
+    "ink_muted": "#586A84",
+    "field": "#FFFFFF",
+    "field_bd": "#C8D3E6",
+    "gold": "#D4B76A",
+    "primary": "#365DC6",
+    "primary_hover": "#587BE2",
+    "on_primary": "#F7FAFF",
+    "tooltip_bg": "#0E1724",
+    "tooltip_fg": "#F7FAFF",
     "scopes": {
         "Env": "#15803d",  # green-700
         "User": "#1e40af",  # blue-900
@@ -56,16 +45,16 @@ _AURELIA_PALETTE: dict[str, dict[str, str]] = {
     },
 }
 
-_ACTIVE_PALETTE: dict[str, dict[str, str]] = _AURELIA_PALETTE
+_ACTIVE_PALETTE: dict[str, object] = _AURELIA_PALETTE.copy()
 
-SCOPE_COLORS = _AURELIA_PALETTE["scopes"]
+SCOPE_COLORS = _AURELIA_PALETTE["scopes"]  # type: ignore[index]
 
 # ---------------------------------------------------------------------------
 # Palette helpers
 # ---------------------------------------------------------------------------
 
 
-def get_palette() -> dict[str, dict[str, str]]:
+def get_palette() -> dict[str, object]:
     """Return the currently active palette."""
 
     return _ACTIVE_PALETTE
@@ -86,6 +75,8 @@ def register_scope_styles(
     ``"Scope.<scope>.Outline.TButton"`` (outline variant).
     """
 
+    palette = get_palette()
+
     for scope, color in scope_colors.items():
         filled = f"Scope.{scope}.TButton"
         outline = f"Scope.{scope}.Outline.TButton"
@@ -93,17 +84,17 @@ def register_scope_styles(
         style.configure(
             filled,
             background=color,
-            foreground=_AURELIA_PALETTE["text"]["on_primary"],
+            foreground=palette["on_primary"],
         )
         style.map(
             filled,
             background=[("active", color)],
-            foreground=[("active", _AURELIA_PALETTE["text"]["on_primary"])],
+            foreground=[("active", palette["on_primary"])],
         )
 
         style.configure(
             outline,
-            background=_AURELIA_PALETTE["neutrals"]["0"],
+            background=palette["card"],
             foreground=color,
             bordercolor=color,
             relief="solid",
@@ -111,7 +102,7 @@ def register_scope_styles(
         )
         style.map(
             outline,
-            background=[("active", _AURELIA_PALETTE["neutrals"]["0"])],
+            background=[("active", palette["card"])],
             foreground=[("active", color)],
         )
 
@@ -121,7 +112,7 @@ def register_scope_styles(
 # ---------------------------------------------------------------------------
 
 
-def use(root: tk.Misc, *, palette: dict[str, dict[str, str]] | None = None) -> None:
+def use(root: tk.Misc, *, palette: dict[str, object] | None = None) -> None:
     """Apply the Aurelia palette to *root*.
 
     ``palette`` can be provided to override the default palette; this also
@@ -136,32 +127,29 @@ def use(root: tk.Misc, *, palette: dict[str, dict[str, str]] | None = None) -> N
         return
 
     style = ttk.Style(root)
-    neutrals = colors["neutrals"]
-    text = colors["text"]
-    accents = colors["accents"]
 
-    root.configure(bg=neutrals["100"])  # type: ignore[call-arg]
+    root.configure(bg=colors["bg"])  # type: ignore[call-arg]
 
-    style.configure("TFrame", background=neutrals["100"])
-    style.configure("TLabel", background=neutrals["100"], foreground=text["fg"])
+    style.configure("TFrame", background=colors["bg"])
+    style.configure("TLabel", background=colors["bg"], foreground=colors["hdr_fg"])
 
     style.configure(
         "Card.TFrame",
-        background=neutrals["0"],
-        bordercolor=neutrals["200"],
+        background=colors["card"],
+        bordercolor=colors["card_edge"],
         borderwidth=1,
         relief="solid",
     )
 
     style.configure(
         "TButton",
-        background=accents["primary"],
-        foreground=text["on_primary"],
+        background=colors["primary"],
+        foreground=colors["on_primary"],
     )
     style.map(
         "TButton",
-        background=[("active", accents["primary_hover"])],
-        foreground=[("disabled", text["muted"])],
+        background=[("active", colors["primary_hover"])],
+        foreground=[("disabled", colors["hdr_muted"])],
     )
 
     register_scope_styles(style, colors["scopes"])

--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -106,20 +106,17 @@ class App:
 
         use(self.root)
         core_palette = get_palette()
-        neutrals = core_palette["neutrals"]
-        text_colors = core_palette["text"]
-        accents = core_palette["accents"]
         self.palette = {
-            "bg": neutrals["100"],
-            "gold": accents["primary"],
-            "hdr_fg": text_colors["fg"],
-            "hdr_muted": text_colors["muted"],
-            "card": neutrals["0"],
-            "card_edge": neutrals["200"],
-            "ink": text_colors["fg"],
-            "ink_muted": text_colors["muted"],
-            "field": neutrals["0"],
-            "field_bd": neutrals["200"],
+            "bg": core_palette["bg"],
+            "gold": core_palette["gold"],
+            "hdr_fg": core_palette["hdr_fg"],
+            "hdr_muted": core_palette["hdr_muted"],
+            "card": core_palette["card"],
+            "card_edge": core_palette["card_edge"],
+            "ink": core_palette["ink"],
+            "ink_muted": core_palette["ink_muted"],
+            "field": core_palette["field"],
+            "field_bd": core_palette["field_bd"],
         }
         self.root.title("pysigil")
         self.root.configure(bg=self.palette["bg"])
@@ -188,7 +185,13 @@ class App:
         )
         style.configure("Title.TLabel", font=(None, 10, "bold"))
 
-        self._table = ttk.Frame(self.root, style="CardFrame.TFrame")
+        self._table = tk.Frame(
+            self.root,
+            bg=palette["card"],
+            highlightthickness=1,
+            highlightbackground=palette["card_edge"],
+            highlightcolor=palette["card_edge"],
+        )
         self._table.pack(fill="both", expand=True, padx=6, pady=6)
 
         self._header = ttk.Frame(self._table, style="CardFrame.TFrame")
@@ -209,23 +212,12 @@ class App:
         self._hdr_edit.grid(row=0, column=3, sticky="ew")
         self._header.columnconfigure(1, weight=1)
 
-        self._rows_container = tk.Frame(
-            self._table,
-            bg=palette["card"],
-            highlightthickness=1,
-            highlightbackground=palette["card_edge"],
-            highlightcolor=palette["card_edge"],
-        )
+        self._rows_container = ttk.Frame(self._table, style="CardFrame.TFrame")
         self._rows_container.pack(fill="both", expand=True)
 
     def _style_row(self, row: FieldRow) -> None:
         palette = self.palette
-        row.configure(
-            bg=palette["card"],
-            highlightthickness=1,
-            highlightbackground=palette["card_edge"],
-            highlightcolor=palette["card_edge"],
-        )
+        row.configure(bg=palette["card"])
         row.key_frame.configure(style="CardFrame.TFrame")
         row.lbl_key.configure(background=palette["card"], foreground=palette["ink"])
         if row.info_btn:

--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -52,8 +52,9 @@ class FieldRow(tk.Frame):
         self.compact = compact
 
         palette = get_palette()
-        text_colors = palette["text"]
-        neutrals = palette["neutrals"]
+        ink = palette["ink"]
+        ink_muted = palette["ink_muted"]
+        field = palette["field"]
 
         # container for key + info button
         self.key_frame = ttk.Frame(self)
@@ -82,7 +83,7 @@ class FieldRow(tk.Frame):
                 self.info_btn = tk.Label(
                     self.key_frame,
                     text="\u24D8",
-                    fg=text_colors["muted"],
+                    fg=ink_muted,
                     cursor="question_arrow",
                     takefocus=1,
                 )
@@ -93,7 +94,7 @@ class FieldRow(tk.Frame):
                 self.lbl_desc = ttk.Label(
                     self,
                     text=info.description_short,
-                    foreground=text_colors["muted"],
+                    foreground=ink_muted,
                     wraplength=360,
                 )
                 self.lbl_desc.grid(row=1, column=0, columnspan=3, sticky="w")
@@ -103,8 +104,8 @@ class FieldRow(tk.Frame):
         self.lbl_eff = tk.Label(
             self,
             textvariable=self.var_eff,
-            bg=neutrals["100"],
-            fg=text_colors["fg"],
+            bg=field,
+            fg=ink,
             bd=1,
             relief="ridge",
             padx=10,
@@ -269,7 +270,7 @@ class FieldRow(tk.Frame):
         short_label = self.adapter.scope_label(name, short=True)
         long_label = self.adapter.scope_label(name, short=False)
         palette = get_palette()
-        color = _SCOPE_COLORS.get(name, palette["text"]["muted"])
+        color = _SCOPE_COLORS.get(name, palette["ink_muted"])
 
         def cb() -> None:
             if not locked and self._on_pill_click:

--- a/src/pysigil/ui/tk/widgets.py
+++ b/src/pysigil/ui/tk/widgets.py
@@ -55,8 +55,8 @@ class HoverTip:
         self.tip.attributes("-topmost", True)
         self.tip.wm_geometry(f"+{x}+{y}")
         palette = get_palette()
-        bg = palette["neutrals"]["900"]
-        fg = palette["text"]["on_primary"]
+        bg = palette["tooltip_bg"]
+        fg = palette["tooltip_fg"]
         frame = tk.Frame(self.tip, bg=bg, bd=0)
         frame.pack()
         label = tk.Label(frame, text=txt, bg=bg, fg=fg, padx=8, pady=6)
@@ -137,31 +137,32 @@ class PillButton(tk.Canvas):
         self.configure(width=w)
         self.delete("all")
         palette = get_palette()
-        neutrals = palette["neutrals"]
-        text = palette["text"]
+        card = palette["card"]
+        card_edge = palette["card_edge"]
+        ink_muted = palette["ink_muted"]
         if self.state == "effective":
             fill = outline = self.color
-            fg = text["on_primary"]
+            fg = palette["on_primary"]
             border_w = 1
         elif self.state == "present":
-            fill = neutrals["0"]
+            fill = card
             outline = self.color
             fg = self.color
             border_w = 2
         elif self.state == "disabled":
-            fill = neutrals["100"]
-            outline = neutrals["200"]
-            fg = text["muted"]
+            fill = card
+            outline = card_edge
+            fg = ink_muted
             border_w = 1
         elif self.state == "synthetic":
-            fill = neutrals["0"]
+            fill = card
             outline = self.color
             fg = self.color
             border_w = 1
         else:  # empty
-            fill = neutrals["0"]
-            outline = neutrals["200"]
-            fg = text["muted"]
+            fill = card
+            outline = card_edge
+            fg = ink_muted
             border_w = 1
         r = self.rad
         self._round_rect(1, 1, w - 1, 26, r, fill=fill, outline=outline, width=border_w)
@@ -172,7 +173,7 @@ class PillButton(tk.Canvas):
                 3,
                 w - 3,
                 24,
-                outline=neutrals["900"],
+                outline=palette["ink"],
                 dash=(2, 2),
             )
 


### PR DESCRIPTION
## Summary
- apply dark Aurelia palette with custom foreground colours
- show settings in a single card without per-row borders
- refresh tooltip and pill styles to match dark theme

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ba31848883288b11103bf8a951c3