### PR TITLE
Align header with table and indent section titles

### DIFF
--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -36,7 +36,7 @@ class SectionFrame(ttk.Frame):  # pragma: no cover - simple container widget
         self._collapsible = collapsible
         self._collapsed = collapsed if collapsible else False
         header = ttk.Frame(self)
-        header.pack(fill="x")
+        header.pack(fill="x", padx=(6, 0))
         if collapsible:
             self._toggle = ttk.Label(header, text="\u25B8" if collapsed else "\u25BE", width=2)
             self._toggle.pack(side="left")
@@ -141,7 +141,7 @@ class App:
         )
 
         header = ttk.Frame(self.root, style="AppHeader.TFrame")
-        header.pack(fill="x", padx=12, pady=12)
+        header.pack(fill="x", padx=18, pady=12)
 
         ttk.Label(header, text="Provider:", style="AppHeader.TLabel").pack(side="left")
         self._provider_var = tk.StringVar()


### PR DESCRIPTION
## Summary
- Align provider and project selectors with table padding for consistent layout
- Add small indentation to section headers so titles aren't flush with card edges

## Testing
- `pytest`
- `pre-commit run --files src/pysigil/ui/tk/__init__.py` *(fails: pre-commit not installed and cannot be installed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c7e31d4c8328aed4090a5b987c2f