### PR TITLE
Add secondary button style and lock state visuals

### DIFF
--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -22,9 +22,32 @@ except Exception:  # pragma: no cover - fallback when tkinter missing
 from ..core import EventBus, AppCore
 from ..provider_adapter import ProviderAdapter
 from ..sections import bucket_by_section, compute_section_order, field_sort_key
-from ..aurelia_theme import get_palette, use
+from ..aurelia_theme import get_palette, use as theme_use
 from .dialogs import EditDialog
 from .rows import FieldRow
+
+
+def use(root: tk.Misc) -> None:
+    """Apply the Aurelia theme and register additional styles."""
+    theme_use(root)
+    if ttk is None:
+        return
+    colors = get_palette()
+    style = ttk.Style(root)
+    style.map("TEntry", foreground=[("readonly", colors["ink"])])
+    style.configure(
+        "Light.Secondary.TButton",
+        background="#F5F7FC",
+        foreground=colors["ink"],
+        bordercolor="#D9E2F3",
+        relief="solid",
+        borderwidth=1,
+    )
+    style.map(
+        "Light.Secondary.TButton",
+        background=[("active", "#EEF2FA")],
+        bordercolor=[("focus", colors["gold"])],
+    )
 
 
 class SectionFrame(ttk.Frame):  # pragma: no cover - simple container widget

--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -165,7 +165,13 @@ class FieldRow(tk.Frame):
             src_txt = "—"
         else:
             src_txt = self.adapter.scope_label(eff_src)
-        self.var_eff.set(f"{val_txt}  ({src_txt})")
+
+        locked = bool(eff_src and not self.adapter.can_write(eff_src))
+        palette = get_palette()
+        fg = palette["ink_muted"] if locked else palette["ink"]
+        lock = "\U0001F512 " if locked else ""
+        self.lbl_eff.configure(fg=fg)
+        self.var_eff.set(f"{lock}{val_txt}  ({src_txt})")
 
         values: Dict[str, ValueInfo] = self.adapter.values_for_key(self.key)
         scopes = self.adapter.scopes()


### PR DESCRIPTION
## Summary
- add Light.Secondary.TButton style using Aurelia palette
- ensure read-only entry text uses ink palette color
- show lock glyph and muted text for locked effective values

## Testing
- `pytest`
- pre-commit *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d587ed4c832883fb012541726c3b