### PR TITLE
Style Edit dialog with card frame and flat buttons

### DIFF
--- a/src/pysigil/ui/aurelia_theme.py
+++ b/src/pysigil/ui/aurelia_theme.py
@@ -155,6 +155,19 @@ def use(root: tk.Misc, *, palette: dict[str, object] | None = None) -> None:
         foreground=[("disabled", colors["ink_muted"])],
     )
 
+    style.configure(
+        "Plain.TButton",
+        background=colors["card"],
+        foreground=colors["ink"],
+        borderwidth=0,
+        relief="flat",
+    )
+    style.map(
+        "Plain.TButton",
+        background=[("active", colors["card_edge"])],
+        foreground=[("disabled", colors["ink_muted"])],
+    )
+
     register_scope_styles(style, colors["scopes"])
 
 

--- a/src/pysigil/ui/tk/dialogs.py
+++ b/src/pysigil/ui/tk/dialogs.py
@@ -38,7 +38,7 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
         self.on_edit_save = on_edit_save
         self.on_edit_remove = on_edit_remove
 
-        body = ttk.Frame(self, padding=12)
+        body = ttk.Frame(self, padding=12, style="Card.TFrame")
         body.pack(fill="both", expand=True)
 
         ttk.Label(body, text=key, font=(None, 12, "bold")).grid(
@@ -85,12 +85,14 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
                 body,
                 text="Save",
                 command=lambda s=scope: self._save_scope(s),
+                style="Plain.TButton",
             )
             btn_save.grid(row=row, column=2, padx=4)
             btn_remove = ttk.Button(
                 body,
                 text="Remove",
                 command=lambda s=scope: self._remove_scope(s),
+                style="Plain.TButton",
             )
             btn_remove.grid(row=row, column=3, padx=4)
 
@@ -106,9 +108,9 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
             self.entries[scope] = entry
             row += 1
 
-        ttk.Button(body, text="Close", command=self.destroy).grid(
-            row=row, column=3, sticky="e"
-        )
+        ttk.Button(
+            body, text="Close", command=self.destroy, style="Plain.TButton"
+        ).grid(row=row, column=3, sticky="e")
         body.columnconfigure(1, weight=1)
 
     # -- callbacks ---------------------------------------------------------


### PR DESCRIPTION
## Summary
- add Plain.TButton style for borderless buttons
- wrap Edit dialog content in Card.TFrame and apply flat button style to actions

## Testing
- `ruff check src/pysigil/ui/aurelia_theme.py src/pysigil/ui/tk/dialogs.py`
- `python -m black src/pysigil/ui/aurelia_theme.py src/pysigil/ui/tk/dialogs.py`
- `pytest tests/ui/test_edit_dialog.py`
- `pre-commit run --files src/pysigil/ui/aurelia_theme.py src/pysigil/ui/tk/dialogs.py` *(failed: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c5de2d9ec08328a96f3d59f1454380