### PR TITLE
Show scope descriptions in pill tooltips

### DIFF
--- a/src/pysigil/ui/provider_adapter.py
+++ b/src/pysigil/ui/provider_adapter.py
@@ -80,10 +80,23 @@ class ProviderAdapter:
         "default": "Default",
     }
 
+    SCOPE_DESCRIPTIONS = {
+        "env": "Overrides from the environment for this run only.",
+        "user": "Applies to all projects for the current user.",
+        "user-local": "User settings specific to this machine.",
+        "project": "Shared project configuration committed to source control.",
+        "project-local": "Project settings for this machine only.",
+        "default": "Built-in default provided by the author.",
+    }
+
     def scope_label(self, scope_id: str, short: bool = False) -> str:
         """Return human readable label for *scope_id*."""
         mapping = self._SHORT_LABELS if short else self._LONG_LABELS
         return mapping.get(scope_id, scope_id)
+
+    def scope_description(self, scope_id: str) -> str:
+        """Return human readable description for ``scope_id``."""
+        return self.SCOPE_DESCRIPTIONS.get(scope_id, scope_id)
 
     def can_write(self, scope_id: str) -> bool:
         """Return ``True`` if *scope_id* is writable according to policy."""

--- a/src/pysigil/ui/tk/dialogs.py
+++ b/src/pysigil/ui/tk/dialogs.py
@@ -120,6 +120,7 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
                 value_provider=value_provider,
                 clickable=False,
                 tooltip_title=long_label,
+                tooltip_desc=adapter.scope_description(scope),
                 locked=locked,
             )
             pill.grid(row=row, column=0, sticky="w", padx=(0, 8), pady=4)

--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -295,6 +295,7 @@ class FieldRow(tk.Frame):
                 clickable=True,
                 on_click=cb,
                 tooltip_title=long_label,
+                tooltip_desc=self.adapter.scope_description(name),
                 locked=locked,
             )
             self._pill_widgets[name] = pill
@@ -306,6 +307,7 @@ class FieldRow(tk.Frame):
             pill.clickable = True
             pill.value_provider = value_provider
             pill.tooltip_title = long_label
+            pill.tooltip_desc = self.adapter.scope_description(name)
             pill.on_click = cb
             pill.bind("<Button-1>", lambda e: cb())
             pill.configure(cursor="hand2")

--- a/src/pysigil/ui/tk/widgets.py
+++ b/src/pysigil/ui/tk/widgets.py
@@ -90,11 +90,13 @@ class PillButton(tk.Canvas):
         clickable: bool = True,
         on_click: Callable[[], None] | None = None,
         tooltip_title: str | None = None,
+        tooltip_desc: str | None = None,
         locked: bool = False,
     ) -> None:
         super().__init__(master, height=28, highlightthickness=0, bd=0)
         self.text = text
         self.tooltip_title = tooltip_title or text
+        self.tooltip_desc = tooltip_desc
         self.color = color
         self.state = state
         self.locked = locked
@@ -209,7 +211,11 @@ class PillButton(tk.Canvas):
     def _tip_text(self) -> str:
         val = self.value_provider()
         val_txt = str(val) if val is not None else "—"
-        return f"{self.tooltip_title}: {val_txt}"
+        parts = [self.tooltip_title]
+        if self.tooltip_desc:
+            parts.append(self.tooltip_desc)
+        parts.append(f"Value: {val_txt}")
+        return "\n".join(parts)
 
 
 __all__ = [

--- a/tests/ui/test_edit_dialog.py
+++ b/tests/ui/test_edit_dialog.py
@@ -10,6 +10,7 @@ except Exception:  # pragma: no cover - tkinter missing
 from pysigil.api import FieldInfo
 from pysigil.ui.tk.dialogs import EditDialog
 from pysigil.ui.provider_adapter import ValueInfo
+from pysigil.ui.tk.widgets import PillButton
 
 
 class DummyAdapter:
@@ -37,6 +38,14 @@ class DummyAdapter:
             description="Long description",
         )
 
+    _DESCRIPTIONS = {
+        "user": "User configuration",
+        "default": "Built-in default",
+    }
+
+    def scope_description(self, scope):
+        return self._DESCRIPTIONS[scope]
+
 
 def test_edit_dialog_default_readonly():
     if tk is None:
@@ -45,7 +54,8 @@ def test_edit_dialog_default_readonly():
         root = tk.Tk()
     except Exception:
         pytest.skip("no display available")
-    dlg = EditDialog(root, DummyAdapter(), "alpha")
+    adapter = DummyAdapter()
+    dlg = EditDialog(root, adapter, "alpha")
     entry = dlg.entries["default"]
     assert entry.instate(["readonly"])  # default is read-only
     row = entry.grid_info()["row"]
@@ -54,6 +64,9 @@ def test_edit_dialog_default_readonly():
     btn_remove = body.grid_slaves(row=row, column=3)[0]
     assert btn_save.instate(["disabled"])
     assert btn_remove.instate(["disabled"])
+    pill = body.grid_slaves(row=row, column=0)[0]
+    assert isinstance(pill, PillButton)
+    assert adapter.scope_description("default") in pill._tip_text()
     dlg.destroy()
     root.destroy()
 

--- a/tests/ui/test_provider_adapter.py
+++ b/tests/ui/test_provider_adapter.py
@@ -71,10 +71,12 @@ def test_field_row_pill_click(tmp_path, monkeypatch):
 
     clicks = []
     row = FieldRow(root, adapter, "alpha", lambda k, s: clicks.append((k, s)), compact=False)
-    states = {p.text: p.state for p in _collect_pills(row)}
+    pills = _collect_pills(row)
+    states = {p.text: p.state for p in pills}
     assert states["User"] == "effective"
-
-    for pill in _collect_pills(row):
+    user_pill = next(p for p in pills if p.text == "User")
+    assert adapter.scope_description("user") in user_pill._tip_text()
+    for pill in pills:
         if pill.text == "User":
             pill.on_click()
             break


### PR DESCRIPTION
## Summary
- map human-readable scope descriptions and expose `scope_description`
- allow `PillButton` tooltips to display a description and value
- use scope descriptions in row and dialog pills and test this behaviour

## Testing
- `pre-commit run --files src/pysigil/ui/provider_adapter.py src/pysigil/ui/tk/dialogs.py src/pysigil/ui/tk/rows.py src/pysigil/ui/tk/widgets.py tests/test_field_row.py tests/ui/test_edit_dialog.py tests/ui/test_provider_adapter.py` *(fails: command not found)*
- `pytest tests/test_field_row.py tests/ui/test_provider_adapter.py tests/ui/test_edit_dialog.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5faa99bc48328849baa37470a84ab