### PR TITLE
Wrap tooltip text to prevent excessive width

### DIFF
--- a/src/pysigil/ui/tk/widgets.py
+++ b/src/pysigil/ui/tk/widgets.py
@@ -9,7 +9,8 @@ setting.
 
 from __future__ import annotations
 
-from typing import Callable, Any, Literal
+from collections.abc import Callable
+from typing import Any, Literal
 
 from ..aurelia_theme import get_palette
 
@@ -19,6 +20,10 @@ try:  # pragma: no cover - importing tkinter is environment dependent
 except Exception:  # pragma: no cover - fallback when tkinter missing
     tk = None  # type: ignore
     tkfont = None  # type: ignore
+
+
+# Maximum width of tooltip labels before wrapping (pixels)
+_TIP_WRAP_LENGTH = 480
 
 
 class HoverTip:
@@ -59,7 +64,16 @@ class HoverTip:
         fg = palette["tooltip_fg"]
         frame = tk.Frame(self.tip, bg=bg, bd=0)
         frame.pack()
-        label = tk.Label(frame, text=txt, bg=bg, fg=fg, padx=8, pady=6)
+        label = tk.Label(
+            frame,
+            text=txt,
+            bg=bg,
+            fg=fg,
+            padx=8,
+            pady=6,
+            justify="left",
+            wraplength=_TIP_WRAP_LENGTH,
+        )
         label.pack()
 
     def _hide(self, _event: tk.Event) -> None:


### PR DESCRIPTION
## Summary
- limit tooltip label width to 480px and enable automatic wrapping

## Testing
- `ruff check src/pysigil/ui/tk/widgets.py`
- `ruff format src/pysigil/ui/tk/widgets.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6123fd6f083289769ae15fd44b8de