### PR TITLE
Add option to hide machine-specific scopes in UI

### DIFF
--- a/src/pysigil/__init__.py
+++ b/src/pysigil/__init__.py
@@ -4,11 +4,17 @@ from .policy import policy
 from .toolkit import helpers_for
 
 
+# Toggle visibility of machine-specific scopes in the UI.  When ``False``
+# machine scopes such as ``user-local`` and ``project-local`` are hidden.
+show_machine_scope = False
+
+
 __all__ = [
     "Sigil",
     "SigilError",
     "parse_key",
     "policy",
     "helpers_for",
+    "show_machine_scope",
 
 ]

--- a/src/pysigil/ui/provider_adapter.py
+++ b/src/pysigil/ui/provider_adapter.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+import pysigil
+
 from .. import api
 from ..policy import policy
 from ..authoring import get as get_dev_link, list_links
@@ -58,8 +60,11 @@ class ProviderAdapter:
 
     def scopes(self) -> List[str]:
         """Return scope ids in display order."""
-        known = set(policy.scopes)
-        order = [s for s in policy.precedence(read=True) if s in known]
+        known = set(getattr(policy, "scopes", []))
+        order = [s for s in policy.precedence(read=True) if not known or s in known]
+        if not pysigil.show_machine_scope:
+            machine = set(policy.machine_scopes())
+            order = [s for s in order if s not in machine]
         return [s for s in order if s != "core"]
 
     _SHORT_LABELS = {

--- a/tests/ui/test_provider_adapter.py
+++ b/tests/ui/test_provider_adapter.py
@@ -12,6 +12,7 @@ from pysigil.ui.tk.widgets import PillButton
 from pysigil.settings_metadata import IniFileBackend, IniSpecBackend
 from pysigil.orchestrator import Orchestrator
 from tests.utils import DummyPolicy
+import pysigil
 
 
 def _setup_adapter(tmp_path, monkeypatch):
@@ -82,6 +83,16 @@ def test_field_row_pill_click(tmp_path, monkeypatch):
             break
     assert clicks == [("alpha", "user")]
     root.destroy()
+
+
+def test_scopes_hide_machine(tmp_path, monkeypatch):
+    adapter, _ = _setup_adapter(tmp_path, monkeypatch)
+    monkeypatch.setattr(pysigil, "show_machine_scope", False)
+    assert "user-local" not in adapter.scopes()
+    assert "project-local" not in adapter.scopes()
+    monkeypatch.setattr(pysigil, "show_machine_scope", True)
+    scopes = adapter.scopes()
+    assert "user-local" in scopes and "project-local" in scopes
 
 
 def test_policy_respected(tmp_path, monkeypatch):

--- a/tests/ui/test_scope_menu.py
+++ b/tests/ui/test_scope_menu.py
@@ -1,0 +1,34 @@
+import pysigil
+from pysigil import api
+from pysigil.ui.scope_menu import build_menu, ScopeRow
+from pysigil.settings_metadata import IniFileBackend, IniSpecBackend
+from pysigil.orchestrator import Orchestrator
+from tests.utils import DummyPolicy
+
+
+def _setup(tmp_path, monkeypatch):
+    spec = IniSpecBackend(user_dir=tmp_path / "meta")
+    pol = DummyPolicy(tmp_path / "user", tmp_path / "proj")
+    cfg = IniFileBackend(policy=pol)
+    orch = Orchestrator(spec_backend=spec, config_backend=cfg)
+    monkeypatch.setattr(api, "_ORCH", orch, raising=False)
+    api.register_provider("demo-sm", title="Demo")
+    handle = api.handle("demo-sm")
+    handle.add_field("alpha", "integer")
+    return handle, pol
+
+
+def _scopes(menu):
+    return [item.scope for item in menu if isinstance(item, ScopeRow)]
+
+
+def test_scope_menu_hides_machine_scopes(tmp_path, monkeypatch):
+    handle, pol = _setup(tmp_path, monkeypatch)
+    monkeypatch.setattr(pysigil, "show_machine_scope", False)
+    menu = build_menu(handle, "alpha", "user", pol)
+    assert "user-local" not in _scopes(menu)
+    assert "project-local" not in _scopes(menu)
+    monkeypatch.setattr(pysigil, "show_machine_scope", True)
+    menu = build_menu(handle, "alpha", "user", pol)
+    scopes = _scopes(menu)
+    assert "user-local" in scopes and "project-local" in scopes


### PR DESCRIPTION
## Summary
- expose global `show_machine_scope` flag
- filter provider scopes and scope menus based on flag
- test that machine-specific scopes can be toggled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c614a33040832889c73f28f52a385a