### PR TITLE
Ensure .sigil folder is packaged during registration

### DIFF
--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from .authoring import (
     DefaultsValidationError,
     DevLinkError,
+    ensure_sigil_package_data,
     link as dev_link,
     list_links as dev_list,
     normalize_provider_id,
@@ -301,6 +302,7 @@ def author_register(args: argparse.Namespace) -> int:
             return 2
         provider_id = default_provider_id(pkg, dist_name)
         settings_path = ensure_defaults_file(pkg, provider_id)
+        ensure_sigil_package_data(root, pkg.name)
         try:
             dev_link(provider_id, settings_path, validate=not args.no_validate)
         except DevLinkError as exc:
@@ -333,6 +335,7 @@ def author_register(args: argparse.Namespace) -> int:
             else default_provider_id(pkg, dist_name)
         )
         settings_path = ensure_defaults_file(pkg, provider_id)
+        ensure_sigil_package_data(root, pkg.name)
         try:
             dev_link(provider_id, settings_path, validate=not args.no_validate)
         except DevLinkError as exc:

--- a/tests/test_package_data.py
+++ b/tests/test_package_data.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+import tomllib
+from pathlib import Path
+
+import pysigil.authoring as authoring
+from pysigil import cli
+from pysigil.authoring import ensure_sigil_package_data
+
+
+def _write_pyproject(root: Path, name: str) -> None:
+    content = f"[project]\nname = \"{name}\"\n"
+    (root / "pyproject.toml").write_text(content, encoding="utf-8")
+
+
+def test_ensure_sigil_package_data(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, "demo")
+    ensure_sigil_package_data(tmp_path, "demo_pkg")
+    data = tomllib.loads((tmp_path / "pyproject.toml").read_text(encoding="utf-8"))
+    assert data["tool"]["setuptools"]["package-data"]["demo_pkg"] == [".sigil/*"]
+    # idempotent
+    ensure_sigil_package_data(tmp_path, "demo_pkg")
+    data = tomllib.loads((tmp_path / "pyproject.toml").read_text(encoding="utf-8"))
+    assert data["tool"]["setuptools"]["package-data"]["demo_pkg"] == [".sigil/*"]
+
+
+def test_author_register_adds_package_data(monkeypatch, tmp_path: Path) -> None:
+    root = tmp_path
+    _write_pyproject(root, "demo-pkg")
+    pkg = root / "src" / "demo_pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").touch()
+
+    monkeypatch.setattr(authoring, "_dev_dir", lambda: tmp_path / "dev")
+    monkeypatch.chdir(root)
+
+    ns = argparse.Namespace(
+        auto=True,
+        package_dir=None,
+        defaults=None,
+        provider=None,
+        no_validate=True,
+    )
+    assert cli.author_register(ns) == 0
+    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    assert data["tool"]["setuptools"]["package-data"]["demo_pkg"] == [".sigil/*"]
+


### PR DESCRIPTION
## Summary
- add helper to insert `.sigil/*` into `pyproject.toml` package data
- call helper from `author register` to include `.sigil` when registering
- test hook and registration behavior

## Testing
- `pre-commit run --files src/pysigil/authoring.py src/pysigil/cli.py tests/test_package_data.py` *(fails: command not found; installation failed: Could not find a version that satisfies the requirement pre-commit)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c80bd28f208328b5126a85bd64a721