### PR TITLE
Allow underscores in defaults keys

### DIFF
--- a/src/pysigil/authoring.py
+++ b/src/pysigil/authoring.py
@@ -125,15 +125,15 @@ class DefaultsValidationError(Exception):
     """Raised when a defaults file is invalid."""
 
 
-_KEY_RE = re.compile(r"^[a-z0-9]+(\.[a-z0-9_]+)*$")
+_KEY_RE = re.compile(r"^[a-z0-9][a-z0-9_]*(\.[a-z0-9_]+)*$")
 
 
 def validate_defaults_file(path: Path, provider_id: str) -> None:
     """Validate ``path`` for ``provider_id``.
 
     The file must contain a ``[<provider_id>]`` section and all keys in that
-    section must be dotted names using lowercase letters, digits and underscores
-    after the first segment.
+    section must be dotted names using lowercase letters, digits, and optional
+    underscores. Keys must start with a letter or digit.
     """
 
     path = Path(path).expanduser().resolve()

--- a/src/pysigil/ui/author_adapter.py
+++ b/src/pysigil/ui/author_adapter.py
@@ -100,7 +100,7 @@ class DeletePreview:
 # ---------------------------------------------------------------------------
 
 
-_KEY_RE = re.compile(r"^[a-z0-9]+(\.[a-z0-9_]+)*$")
+_KEY_RE = re.compile(r"^[a-z0-9][a-z0-9_]*(\.[a-z0-9_]+)*$")
 
 
 class AuthorAdapter:

--- a/tests/test_authoring_validation.py
+++ b/tests/test_authoring_validation.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pytest
+
+from pysigil.authoring import DefaultsValidationError, validate_defaults_file
+
+
+def _write_ini(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "settings.ini"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_validate_defaults_allows_underscores(tmp_path: Path) -> None:
+    ini = _write_ini(tmp_path, "[demo]\ndefault_loc = ./here\n")
+    validate_defaults_file(ini, "demo")
+
+
+def test_validate_defaults_rejects_leading_underscore(tmp_path: Path) -> None:
+    ini = _write_ini(tmp_path, "[demo]\n_invalid = nope\n")
+    with pytest.raises(DefaultsValidationError):
+        validate_defaults_file(ini, "demo")


### PR DESCRIPTION
## Summary
- allow underscores in defaults file keys by relaxing the validation regex
- update the authoring adapter to mirror the key validation change
- add regression tests covering underscore handling in defaults keys

## Testing
- pytest tests/test_authoring_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68c9e22a258c8328bfe57b3444f83680