### PR TITLE
Support environment scope writes in Sigil

### DIFF
--- a/tests/test_core_basic.py
+++ b/tests/test_core_basic.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -57,4 +58,19 @@ def test_explicit_default_path_writable(tmp_path: Path) -> None:
     assert "foo = bar" in settings_file.read_text()
     s2 = Sigil("demo", user_scope=tmp_path / "user2.ini", default_path=default_dir, policy=policy)
     assert s2.get_pref("foo") == "bar"
+
+
+def test_environment_scope_updates_environ(monkeypatch, tmp_path: Path) -> None:
+    sigil = Sigil("demo", user_scope=tmp_path / "user", policy=policy)
+    env_key = "SIGIL_DEMO_SECTION_VALUE"
+    monkeypatch.delenv(env_key, raising=False)
+
+    try:
+        sigil.set_pref("section.value", "123", scope="env")
+        assert os.environ[env_key] == "123"
+        assert sigil.get_pref("section.value") == 123
+    finally:
+        sigil.set_pref("section.value", None, scope="env")
+    assert env_key not in os.environ
+    assert sigil.get_pref("section.value") is None
 

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 
@@ -8,6 +9,7 @@ from pysigil import helpers_for
 
 def test_helpers_for_isolated_apps(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.delenv("SIGIL_DEMO_SECTION_VALUE", raising=False)
 
     get_a, set_a = helpers_for("demo")
     set_a("section.value", "1")
@@ -20,4 +22,21 @@ def test_helpers_for_isolated_apps(monkeypatch, tmp_path: Path) -> None:
 
     # original demo settings remain unchanged
     assert get_a("section.value", cast=int) == 1
+
+
+def test_helpers_environment_scope(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+    get_setting, set_setting = helpers_for("demo-env")
+    env_key = "SIGIL_DEMO_ENV_SECTION_VALUE"
+    monkeypatch.delenv(env_key, raising=False)
+
+    try:
+        set_setting("section.value", "7", scope="environment")
+        assert os.environ[env_key] == "7"
+        assert get_setting("section.value") == 7
+    finally:
+        set_setting("section.value", None, scope="env")
+    assert env_key not in os.environ
+    assert get_setting("section.value") is None
 


### PR DESCRIPTION
## Summary
- allow `Sigil.set_pref` to recognise the environment scope and write/delete environment variables
- add helper to build environment variable names with sanitisation of application and key segments
- cover the new behaviour with tests for the core Sigil class and the public helpers API

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9e56dcaf08328b9b8583b890d9a1c