### PR TITLE
Expose project and user data directory helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ python -m pysigil --help
 ```
 
 ```python
-from pysigil import helpers_for
+from pysigil import get_project_directory, get_user_directory, helpers_for
 
 get_setting, set_setting = helpers_for("pysigil")
+project_assets = get_project_directory("pysigil")
+user_assets = get_user_directory("pysigil")
 
 get_setting("ui.color")
 set_setting("ui.color", "blue")
+print(project_assets)
+print(user_assets)
 ```
 
 Once installed, try a few commands:
@@ -42,6 +46,8 @@ separate project. See `tests/manual_tests/README.md` for more examples.
 
 Typed helper methods are available for convenient access:
 `Sigil.get_int()`, `get_float()`, `get_bool()`.
+Project and user data folders are provided via
+`get_project_directory()` / `get_user_directory()` and are created on demand.
 For package integration details see [docs/integration.md](docs/integration.md).
 
 ## Policy API

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -24,12 +24,18 @@ sigil author register --auto  # or `sigil setup` / `sigil register`
 | 4 | (Optional) Expose helpers so callers never touch pysigil APIs | ```python
 # mypkg/__init__.py
 
-from pysigil import helpers_for
+from pysigil import (
+    get_project_directory,
+    get_user_directory,
+    helpers_for,
+)
 
 get_setting, set_setting = helpers_for(__name__)
-__all__ = ["get_setting", "set_setting"]
+PROJECT_DATA = get_project_directory(__name__)
+USER_DATA = get_user_directory(__name__)
+__all__ = ["get_setting", "set_setting", "PROJECT_DATA", "USER_DATA"]
 
-``` | • One-line access:<br>`get_setting("db.host")`<br>• Handles env ▶ project ▶ user ▶ defaults without extra code. |
+``` | • One-line access:<br>`get_setting("db.host")`<br>• Handles env ▶ project ▶ user ▶ defaults without extra code.<br>• Ready-to-use app-specific folders for data files. |
 
 Launch authoring tools without starting the main editor:
 
@@ -49,6 +55,20 @@ If you don't need that separation simply ignore it—`pysigil` works fine withou
 the extra file.
 
 No boiler-plate: call `get_setting()` / `set_setting()` from anywhere in your code.
+
+Need to ship additional assets (templates, caches, exports)?  Use
+`get_project_directory()` for project-scoped data and `get_user_directory()` for
+per-user storage.  Both functions create the directories on demand and normalise
+the application name so that ``mypkg`` and ``My-Pkg`` stay in sync with the
+settings helpers:
+
+```python
+from pysigil import get_project_directory, get_user_directory, helpers_for
+
+get_setting, set_setting = helpers_for(__name__)
+shared_assets = get_project_directory(__name__) / "templates"
+user_exports = get_user_directory(__name__) / "exports"
+```
 
 User tooling already works:
 

--- a/src/pysigil/__init__.py
+++ b/src/pysigil/__init__.py
@@ -1,7 +1,7 @@
 from .core import Sigil, SigilError
 from .merge_policy import parse_key
 from .policy import policy
-from .toolkit import helpers_for
+from .toolkit import helpers_for, get_project_directory, get_user_directory
 
 
 # Toggle visibility of machine-specific scopes in the UI.  When ``False``
@@ -15,6 +15,8 @@ __all__ = [
     "parse_key",
     "policy",
     "helpers_for",
+    "get_project_directory",
+    "get_user_directory",
     "show_machine_scope",
 
 ]

--- a/src/pysigil/toolkit.py
+++ b/src/pysigil/toolkit.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Callable
 
+from .authoring import normalize_provider_id
 from .core import Sigil
+from .discovery import pep503_name
+from .paths import project_data_dir, user_data_dir
 
-__all__ = ["helpers_for"]
+__all__ = ["helpers_for", "get_project_directory", "get_user_directory"]
 
 
 def helpers_for(app_name: str) -> tuple[Callable[..., Any], Callable[..., None]]:
@@ -33,3 +37,44 @@ def helpers_for(app_name: str) -> tuple[Callable[..., Any], Callable[..., None]]
         sigil.set_pref(key, value, scope=scope)
 
     return get_setting, set_setting
+
+
+def _normalise_app_name(app_name: str) -> str:
+    try:
+        normalize_provider_id(app_name)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"invalid application name: {app_name!r}") from exc
+    return pep503_name(app_name)
+
+
+def get_project_directory(
+    app_name: str,
+    /,
+    *,
+    start: str | Path | None = None,
+    **kwargs: Any,
+) -> Path:
+    """Return the project data directory for ``app_name``.
+
+    The directory lives under ``<project-root>/.sigil/data/<app-name>`` and is
+    created if necessary. ``start`` and ``**kwargs`` are forwarded to
+    :func:`pysigil.paths.project_data_dir` for custom root resolution.
+    """
+
+    app = _normalise_app_name(app_name)
+    path = (project_data_dir(start=start, **kwargs) / app).resolve()
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_user_directory(app_name: str) -> Path:
+    """Return the user data directory for ``app_name``.
+
+    The directory lives under the platform-specific user data root and is
+    created if necessary.
+    """
+
+    app = _normalise_app_name(app_name)
+    path = user_data_dir(app)
+    path.mkdir(parents=True, exist_ok=True)
+    return path

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -4,7 +4,8 @@ import os
 from pathlib import Path
 
 
-from pysigil import helpers_for
+from pysigil import get_project_directory, get_user_directory, helpers_for
+from pysigil.discovery import pep503_name
 
 
 def test_helpers_for_isolated_apps(monkeypatch, tmp_path: Path) -> None:
@@ -39,4 +40,29 @@ def test_helpers_environment_scope(monkeypatch, tmp_path: Path) -> None:
         set_setting("section.value", None, scope="env")
     assert env_key not in os.environ
     assert get_setting("section.value") is None
+
+
+def test_directory_helpers_return_app_specific_paths(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("SIGIL_ROOT", str(tmp_path / "project"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    monkeypatch.delenv("SIGIL_APP_NAME", raising=False)
+
+    app_name = "Demo_App"
+    expected = pep503_name(app_name)
+
+    project_dir = get_project_directory(app_name)
+    user_dir = get_user_directory(app_name)
+
+    assert project_dir.is_absolute()
+    assert user_dir.is_absolute()
+
+    assert project_dir.name == expected
+    assert project_dir.parent == (tmp_path / "project" / ".sigil" / "data").resolve()
+    assert project_dir.is_dir()
+
+    assert user_dir.name == expected
+    assert user_dir.parent == (tmp_path / "xdg").resolve()
+    assert user_dir.is_dir()
 


### PR DESCRIPTION
## Summary
- add `get_project_directory` and `get_user_directory` to the toolkit and package exports
- cover the new helpers with unit tests that ensure absolute, app-specific paths
- document how package authors can consume the helpers for non-setting assets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9fa6c8e5c83288df0d9b2812169da