### PR TITLE
Add toolkit directory helpers for project assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,20 @@ python -m pysigil --help
 ```
 
 ```python
-from pysigil import helpers_for
+from pysigil import (
+    get_project_directory,
+    get_user_directory,
+    helpers_for,
+)
 
 get_setting, set_setting = helpers_for("pysigil")
+project_root = get_project_directory("pysigil")
+user_data = get_user_directory("pysigil")
 
 get_setting("ui.color")
 set_setting("ui.color", "blue")
+# e.g. load a template shipped with the package
+(project_root / "templates" / "dialog.ui").read_text()
 ```
 
 Once installed, try a few commands:

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -24,12 +24,24 @@ sigil author register --auto  # or `sigil setup` / `sigil register`
 | 4 | (Optional) Expose helpers so callers never touch pysigil APIs | ```python
 # mypkg/__init__.py
 
-from pysigil import helpers_for
+from pysigil import (
+    get_project_directory,
+    get_user_directory,
+    helpers_for,
+)
 
 get_setting, set_setting = helpers_for(__name__)
-__all__ = ["get_setting", "set_setting"]
+ASSETS_DIR = get_project_directory(__name__) / "assets"
+USER_STATE_DIR = get_user_directory(__name__)
 
-``` | • One-line access:<br>`get_setting("db.host")`<br>• Handles env ▶ project ▶ user ▶ defaults without extra code. |
+__all__ = [
+    "get_setting",
+    "set_setting",
+    "ASSETS_DIR",
+    "USER_STATE_DIR",
+]
+
+``` | • One-line access:<br>`get_setting("db.host")`<br>• Handles env ▶ project ▶ user ▶ defaults without extra code.<br>• Shared helpers expose project/user folders for non-setting data. |
 
 Launch authoring tools without starting the main editor:
 
@@ -64,6 +76,11 @@ Zero runtime deps: pysigil is pure std-lib + your INI file.
 That’s it. Add one defaults file, register a dev link, (optionally) four helper
 lines — and your package instantly gains a robust, chain-aware configuration
 system.
+
+Need non-setting assets?  The toolkit helpers now include
+``get_project_directory()`` for locating files bundled with your package (such
+as templates or migrations) and ``get_user_directory()`` for per-user caches or
+exports.  Both accept the same application name you pass to ``helpers_for()``.
 
 ## Custom scopes
 

--- a/src/pysigil/__init__.py
+++ b/src/pysigil/__init__.py
@@ -1,7 +1,7 @@
 from .core import Sigil, SigilError
 from .merge_policy import parse_key
 from .policy import policy
-from .toolkit import helpers_for
+from .toolkit import get_project_directory, get_user_directory, helpers_for
 
 
 # Toggle visibility of machine-specific scopes in the UI.  When ``False``
@@ -15,6 +15,7 @@ __all__ = [
     "parse_key",
     "policy",
     "helpers_for",
+    "get_project_directory",
+    "get_user_directory",
     "show_machine_scope",
-
 ]

--- a/src/pysigil/toolkit.py
+++ b/src/pysigil/toolkit.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Callable
+
+import pysigil.paths as _paths
 
 from .core import Sigil
 
-__all__ = ["helpers_for"]
+__all__ = ["helpers_for", "get_project_directory", "get_user_directory"]
 
 
 def helpers_for(app_name: str) -> tuple[Callable[..., Any], Callable[..., None]]:
@@ -33,3 +36,15 @@ def helpers_for(app_name: str) -> tuple[Callable[..., Any], Callable[..., None]]
         sigil.set_pref(key, value, scope=scope)
 
     return get_setting, set_setting
+
+
+def get_project_directory(package_name: str) -> Path:
+    """Return the root directory for an importable *package_name*."""
+
+    return _paths.project_dir(package_name)
+
+
+def get_user_directory(app_name: str) -> Path:
+    """Return the per-user data directory for *app_name*."""
+
+    return _paths.user_data_dir(app_name)

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import importlib
 import os
+import sys
 from pathlib import Path
 
 
-from pysigil import helpers_for
+from pysigil import (
+    get_project_directory,
+    get_user_directory,
+    helpers_for,
+)
 
 
 def test_helpers_for_isolated_apps(monkeypatch, tmp_path: Path) -> None:
@@ -39,4 +45,54 @@ def test_helpers_environment_scope(monkeypatch, tmp_path: Path) -> None:
         set_setting("section.value", None, scope="env")
     assert env_key not in os.environ
     assert get_setting("section.value") is None
+
+
+def test_get_user_directory_is_app_specific(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("SIGIL_APP_NAME", raising=False)
+
+    calls: list[str] = []
+
+    def fake_user_data_dir(*, appname: str) -> Path:
+        calls.append(appname)
+        return tmp_path / f"data-{appname}"
+
+    monkeypatch.setattr("pysigil.paths._ud", fake_user_data_dir)
+
+    first = get_user_directory("alpha-app")
+    second = get_user_directory("beta-app")
+
+    assert first == (tmp_path / "data-alpha-app").resolve()
+    assert second == (tmp_path / "data-beta-app").resolve()
+    assert first.is_absolute()
+    assert second.is_absolute()
+    assert calls == ["alpha-app", "beta-app"]
+
+
+def test_get_project_directory_returns_package_root(
+    monkeypatch, tmp_path: Path
+) -> None:
+    names = ("toolkit_pkg_alpha", "toolkit_pkg_beta")
+    roots = {}
+    for name in names:
+        root = tmp_path / name
+        pkg_dir = root / name
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
+        (root / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+        monkeypatch.syspath_prepend(str(root))
+        roots[name] = root.resolve()
+
+    importlib.invalidate_caches()
+
+    try:
+        resolved = {name: get_project_directory(name) for name in names}
+    finally:
+        for name in names:
+            sys.modules.pop(name, None)
+
+    assert resolved["toolkit_pkg_alpha"].is_absolute()
+    assert resolved["toolkit_pkg_beta"].is_absolute()
+    assert resolved["toolkit_pkg_alpha"] == roots["toolkit_pkg_alpha"]
+    assert resolved["toolkit_pkg_beta"] == roots["toolkit_pkg_beta"]
+    assert resolved["toolkit_pkg_alpha"] != resolved["toolkit_pkg_beta"]
 


### PR DESCRIPTION
## Summary
- add toolkit wrappers that expose project and user directories and re-export them from the package root
- teach pysigil.paths how to resolve a package project directory and cover the helpers with unit tests
- document the new helpers for package authors in the README and integration guide

## Testing
- pytest
- pytest tests/test_toolkit.py

------
https://chatgpt.com/codex/tasks/task_e_68ca126eb5e48328a47da39c330cbd96