### PR TITLE
Fix GUI defaults precedence

### DIFF
--- a/src/pysigil/settings_metadata.py
+++ b/src/pysigil/settings_metadata.py
@@ -707,13 +707,13 @@ class IniFileBackend:
         return self.policy.path(scope, provider_id)
 
     def _iter_read_paths(self, provider_id: str) -> Iterable[tuple[str, Path]]:
-        dl = get_dev_link(provider_id)
+        defaults_path, _source = resolve_defaults(provider_id, "settings.ini")
         for scope in reversed(self.policy.precedence(read=True)):
             if scope in {"env", "core"}:
                 continue
             if scope == "default":
-                if dl is not None and dl.defaults_path.is_file():
-                    yield "default", dl.defaults_path
+                if defaults_path is not None:
+                    yield "default", defaults_path
                 continue
             try:
                 yield scope, self.policy.path(scope, provider_id)


### PR DESCRIPTION
## Summary
- ensure the INI backend resolves default scope files via `resolve_defaults`
- add a regression test covering installed defaults winning over dev links

## Testing
- pytest tests/test_settings_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_68cb149d7f408328b56b97f12bea5421