### PR TITLE
Modularize Aurelia theme via shared theme manager

### DIFF
--- a/src/pysigil/ui/aurelia_theme.py
+++ b/src/pysigil/ui/aurelia_theme.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-"""Aurelia ttk theme helpers.
+"""Aurelia ttk theme palette definitions."""
 
-This module defines the colour palette used by the tkinter interface and
-provides helpers for applying the palette to a ``tkinter`` application.
-External callers can access the palette via :func:`get_palette` and
-register scope specific button styles with :func:`register_scope_styles`.
-"""
+from typing import Mapping
 
 try:  # pragma: no cover - importing tkinter is environment dependent
     import tkinter as tk
@@ -15,24 +11,21 @@ except Exception:  # pragma: no cover - fallback when tkinter missing
     tk = None  # type: ignore
     ttk = None  # type: ignore
 
-# ---------------------------------------------------------------------------
-# Palette
-# ---------------------------------------------------------------------------
+from .theme import ThemeSpec, apply_theme, get_active_palette, register_scope_styles as _register_scope_styles
 
 _AURELIA_PALETTE: dict[str, object] = {
     "bg": "#2B313B",
     "card": "#EEF3FA",
     "card_edge": "#D4DEEE",
     "hdr_fg": "#F4F8FF",
-    #"hdr_fg": "#f1d48e",
     "hdr_muted": "#C3CFE4",
     "ink": "#0E1724",
     "ink_muted": "#586A84",
     "field": "#FFFFFF",
     "field_bd": "#C8D3E6",
     "gold": "#D4B76A",
-    "gold_hi":"#f1d48e",
-    "title_accent":"#f1d48e",
+    "gold_hi": "#f1d48e",
+    "title_accent": "#f1d48e",
     "primary": "#365DC6",
     "primary_hover": "#587BE2",
     "on_primary": "#F7FAFF",
@@ -48,130 +41,28 @@ _AURELIA_PALETTE: dict[str, object] = {
     },
 }
 
-_ACTIVE_PALETTE: dict[str, object] = _AURELIA_PALETTE.copy()
+SCOPE_COLORS: dict[str, str] = _AURELIA_PALETTE["scopes"]  # type: ignore[index]
 
-SCOPE_COLORS = _AURELIA_PALETTE["scopes"]  # type: ignore[index]
-
-# ---------------------------------------------------------------------------
-# Palette helpers
-# ---------------------------------------------------------------------------
+THEME = ThemeSpec(name="aurelia", ttk_theme="clam", palette=_AURELIA_PALETTE)
 
 
 def get_palette() -> dict[str, object]:
-    """Return the currently active palette."""
+    """Return the palette for the active Aurelia theme."""
 
-    return _ACTIVE_PALETTE
-
-
-# ---------------------------------------------------------------------------
-# Style registration
-# ---------------------------------------------------------------------------
+    palette = get_active_palette()
+    return palette if palette else _AURELIA_PALETTE
 
 
-def register_scope_styles(
-    style: ttk.Style, scope_colors: dict[str, str]
-) -> None:  # pragma: no cover - thin wrapper over ttk
-    """Register per-scope button styles on *style*.
+def use(root: tk.Misc, *, palette: Mapping[str, object] | None = None) -> None:
+    """Apply the Aurelia theme to *root*."""
 
-    For each ``scope`` and ``color`` pair in *scope_colors* two styles are
-    created: ``"Scope.<scope>.TButton"`` (filled) and
-    ``"Scope.<scope>.Outline.TButton"`` (outline variant).
-    """
-
-    palette = get_palette()
-
-    for scope, color in scope_colors.items():
-        filled = f"Scope.{scope}.TButton"
-        outline = f"Scope.{scope}.Outline.TButton"
-
-        style.configure(
-            filled,
-            background=color,
-            foreground=palette["on_primary"],
-        )
-        style.map(
-            filled,
-            background=[("active", color)],
-            foreground=[("active", palette["on_primary"])],
-        )
-
-        style.configure(
-            outline,
-            background=palette["card"],
-            foreground=color,
-            bordercolor=color,
-            relief="solid",
-            borderwidth=1,
-        )
-        style.map(
-            outline,
-            background=[("active", palette["card"])],
-            foreground=[("active", color)],
-        )
+    apply_theme(root, THEME, palette_override=palette)
 
 
-# ---------------------------------------------------------------------------
-# Theme application
-# ---------------------------------------------------------------------------
+def register_scope_styles(style: ttk.Style, scope_colors: Mapping[str, str]) -> None:
+    """Register scope-specific styles for Aurelia."""
+
+    _register_scope_styles(style, scope_colors)
 
 
-def use(root: tk.Misc, *, palette: dict[str, object] | None = None) -> None:
-    """Apply the Aurelia palette to *root*.
-
-    ``palette`` can be provided to override the default palette; this also
-    updates the palette returned by :func:`get_palette`.
-    """
-
-    global _ACTIVE_PALETTE
-    colors = palette or _AURELIA_PALETTE
-    _ACTIVE_PALETTE = colors
-
-    if ttk is None:
-        return
-
-    style = ttk.Style(root)
-
-    root.configure(bg=colors["bg"])  # type: ignore[call-arg]
-
-    style.configure("TFrame", background=colors["bg"])
-    style.configure("TLabel", background=colors["bg"], foreground=colors["hdr_fg"])
-
-    style.configure(
-        "Card.TFrame",
-        background=colors["card"],
-        bordercolor=colors["card_edge"],
-        borderwidth=1,
-        relief="solid",
-    )
-
-    style.configure(
-        "TButton",
-        background=colors["card"],
-        foreground=colors["ink"],
-        bordercolor=colors["field_bd"],
-        borderwidth=1,
-        relief="solid",
-    )
-    style.map(
-        "TButton",
-        background=[("active", colors["card_edge"])],
-        foreground=[("disabled", colors["ink_muted"])],
-    )
-
-    style.configure(
-        "Plain.TButton",
-        background=colors["card"],
-        foreground=colors["ink"],
-        borderwidth=0,
-        relief="flat",
-    )
-    style.map(
-        "Plain.TButton",
-        background=[("active", colors["card_edge"])],
-        foreground=[("disabled", colors["ink_muted"])],
-    )
-
-    register_scope_styles(style, colors["scopes"])
-
-
-__all__ = ["use", "get_palette", "register_scope_styles", "SCOPE_COLORS"]
+__all__ = ["THEME", "use", "get_palette", "register_scope_styles", "SCOPE_COLORS"]

--- a/src/pysigil/ui/theme.py
+++ b/src/pysigil/ui/theme.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+"""Toolkit-agnostic theme management for tkinter UIs."""
+
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping
+
+try:  # pragma: no cover - importing tkinter is environment dependent
+    import tkinter as tk
+    from tkinter import ttk
+except Exception:  # pragma: no cover - fallback when tkinter missing
+    tk = None  # type: ignore
+    ttk = None  # type: ignore
+
+
+@dataclass(frozen=True)
+class ThemeSpec:
+    """Description of a theme that can be applied to a tkinter UI."""
+
+    name: str
+    ttk_theme: str
+    palette: Mapping[str, object]
+
+    def with_palette(self, palette: Mapping[str, object]) -> "ThemeSpec":
+        """Return a copy of the theme using *palette* instead of the default."""
+
+        return ThemeSpec(name=self.name, ttk_theme=self.ttk_theme, palette=palette)
+
+
+_ACTIVE_THEME: ThemeSpec | None = None
+_ACTIVE_PALETTE: dict[str, object] = {}
+
+
+def get_active_palette() -> dict[str, object]:
+    """Return the palette from the most recently applied theme."""
+
+    return _ACTIVE_PALETTE
+
+
+def apply_theme(
+    root: tk.Misc,
+    theme: ThemeSpec,
+    *,
+    palette_override: Mapping[str, object] | None = None,
+) -> None:
+    """Apply *theme* to *root* with an optional palette override."""
+
+    global _ACTIVE_THEME, _ACTIVE_PALETTE
+
+    colors: dict[str, object] = dict(palette_override or theme.palette)
+    _ACTIVE_THEME = theme.with_palette(colors)
+    _ACTIVE_PALETTE = colors
+
+    if ttk is None:  # pragma: no cover - ttk unavailable in some environments
+        return
+
+    style = ttk.Style(root)
+    try:  # pragma: no branch - prefer requested ttk theme but fall back silently
+        style.theme_use(theme.ttk_theme)
+    except Exception:  # pragma: no cover - best effort on unsupported themes
+        pass
+
+    root.configure(bg=colors["bg"])  # type: ignore[call-arg]
+    try:  # pragma: no branch - tk palette calls may fail on some platforms
+        root.tk_setPalette(
+            background=colors["bg"],
+            foreground=colors["ink"],
+            activeBackground=colors["primary_hover"],
+            activeForeground=colors["on_primary"],
+            highlightColor=colors["gold"],
+            highlightBackground=colors["bg"],
+            selectColor=colors["primary"],
+        )
+    except Exception:
+        pass
+
+    option_add = getattr(root, "option_add", None)
+    if callable(option_add):
+        option_add("*background", colors["bg"])
+        option_add("*foreground", colors["ink"])
+        option_add("*selectBackground", colors["primary_hover"])
+        option_add("*selectForeground", colors["on_primary"])
+        option_add("*insertBackground", colors["ink"])
+        option_add("*troughColor", colors["card_edge"])
+        option_add("*activeBackground", colors["primary_hover"])
+        option_add("*activeForeground", colors["on_primary"])
+        option_add("*highlightColor", colors["gold"])
+
+    style.configure("TFrame", background=colors["bg"])
+    style.configure("TLabel", background=colors["bg"], foreground=colors["hdr_fg"])
+
+    style.configure(
+        "TMenubutton",
+        background=colors["card"],
+        foreground=colors["ink"],
+        borderwidth=1,
+        relief="solid",
+    )
+
+    style.configure(
+        "Card.TFrame",
+        background=colors["card"],
+        bordercolor=colors["card_edge"],
+        borderwidth=1,
+        relief="solid",
+    )
+    style.configure("CardBody.TFrame", background=colors["card"])
+    style.configure("CardSection.TFrame", background=colors["card"])
+
+    style.configure(
+        "TButton",
+        background=colors["card"],
+        foreground=colors["ink"],
+        bordercolor=colors["field_bd"],
+        borderwidth=1,
+        relief="solid",
+    )
+    style.map(
+        "TButton",
+        background=[("active", colors["card_edge"])],
+        foreground=[("disabled", colors["ink_muted"])],
+    )
+
+    style.configure(
+        "TCheckbutton",
+        background=colors["bg"],
+        foreground=colors["hdr_muted"],
+        indicatorcolor=colors["card"],
+        focusthickness=1,
+        focuscolor=colors["primary"],
+    )
+    style.map(
+        "TCheckbutton",
+        foreground=[("disabled", colors["ink_muted"]), ("active", colors["hdr_fg"])],
+        indicatorcolor=[("selected", colors["primary"]), ("!selected", colors["card_edge"])],
+    )
+
+    style.configure(
+        "Card.TCheckbutton",
+        background=colors["card"],
+        foreground=colors["ink"],
+        indicatorcolor=colors["card_edge"],
+        focusthickness=1,
+        focuscolor=colors["primary"],
+    )
+    style.map(
+        "Card.TCheckbutton",
+        foreground=[("disabled", colors["ink_muted"]), ("active", colors["ink"])],
+        indicatorcolor=[("selected", colors["primary"]), ("!selected", colors["card_edge"])],
+        background=[("active", colors["card_edge"])],
+    )
+
+    style.configure(
+        "TRadiobutton",
+        background=colors["bg"],
+        foreground=colors["hdr_muted"],
+        indicatorcolor=colors["card"],
+        focusthickness=1,
+        focuscolor=colors["primary"],
+    )
+    style.map(
+        "TRadiobutton",
+        foreground=[("disabled", colors["ink_muted"]), ("active", colors["hdr_fg"])],
+        indicatorcolor=[("selected", colors["primary"]), ("!selected", colors["card_edge"])],
+    )
+
+    style.configure(
+        "Plain.TButton",
+        background=colors["card"],
+        foreground=colors["ink"],
+        borderwidth=0,
+        relief="flat",
+    )
+    style.map(
+        "Plain.TButton",
+        background=[("active", colors["card_edge"])],
+        foreground=[("disabled", colors["ink_muted"])],
+    )
+
+    style.configure(
+        "Toolbutton",
+        background=colors["card"],
+        foreground=colors["ink"],
+        bordercolor=colors["field_bd"],
+        borderwidth=1,
+        focusthickness=1,
+        focuscolor=colors["primary"],
+        relief="solid",
+        padding=4,
+    )
+    style.map(
+        "Toolbutton",
+        background=[("selected", colors["primary"]), ("active", colors["card_edge"])],
+        foreground=[("selected", colors["on_primary"]), ("disabled", colors["ink_muted"])],
+    )
+
+    style.configure(
+        "Card.TLabel",
+        background=colors["card"],
+        foreground=colors["ink"],
+    )
+    style.configure(
+        "CardKey.TLabel",
+        background=colors["card"],
+        foreground=colors["ink"],
+        font=(None, 10, "bold"),
+    )
+    style.configure(
+        "CardMuted.TLabel",
+        background=colors["card"],
+        foreground=colors["ink_muted"],
+    )
+    style.configure(
+        "CardSection.TLabel",
+        background=colors["card"],
+        foreground=colors["ink"],
+        font=(None, 12, "bold"),
+    )
+    style.configure(
+        "CardToggle.TLabel",
+        background=colors["card"],
+        foreground=colors["ink_muted"],
+    )
+
+    style.configure(
+        "TEntry",
+        padding=6,
+        foreground=colors["ink"],
+        fieldbackground=colors["field"],
+        background=colors["field"],
+        insertcolor=colors["ink"],
+        bordercolor=colors["field_bd"],
+        lightcolor=colors["field_bd"],
+        darkcolor=colors["field_bd"],
+        borderwidth=1,
+        relief="solid",
+    )
+    style.map(
+        "TEntry",
+        fieldbackground=[("readonly", colors["card_edge"]), ("disabled", colors["card_edge"])],
+        foreground=[("disabled", colors["ink_muted"])],
+        bordercolor=[("focus", colors["primary"])],
+        lightcolor=[("focus", colors["primary"])],
+        darkcolor=[("focus", colors["primary"])],
+    )
+
+    style.configure(
+        "TCombobox",
+        padding=4,
+        background=colors["field"],
+        foreground=colors["ink"],
+        fieldbackground=colors["field"],
+        arrowcolor=colors["ink"],
+        bordercolor=colors["field_bd"],
+        lightcolor=colors["field_bd"],
+        darkcolor=colors["field_bd"],
+        borderwidth=1,
+        relief="solid",
+    )
+    style.map(
+        "TCombobox",
+        fieldbackground=[("readonly", colors["field"]), ("disabled", colors["card_edge"])],
+        foreground=[("disabled", colors["ink_muted"])],
+        arrowcolor=[("pressed", colors["primary"]), ("active", colors["primary"])],
+        bordercolor=[("focus", colors["primary"])],
+        lightcolor=[("focus", colors["primary"])],
+        darkcolor=[("focus", colors["primary"])],
+    )
+
+    style.configure(
+        "TSpinbox",
+        padding=4,
+        background=colors["field"],
+        foreground=colors["ink"],
+        fieldbackground=colors["field"],
+        arrowcolor=colors["ink"],
+        bordercolor=colors["field_bd"],
+        lightcolor=colors["field_bd"],
+        darkcolor=colors["field_bd"],
+        borderwidth=1,
+        relief="solid",
+    )
+    style.map(
+        "TSpinbox",
+        fieldbackground=[("readonly", colors["field"]), ("disabled", colors["card_edge"])],
+        foreground=[("disabled", colors["ink_muted"])],
+        arrowcolor=[("pressed", colors["primary"]), ("active", colors["primary"])],
+        bordercolor=[("focus", colors["primary"])],
+        lightcolor=[("focus", colors["primary"])],
+        darkcolor=[("focus", colors["primary"])],
+    )
+
+    style.configure(
+        "TLabelframe",
+        background=colors["card"],
+        bordercolor=colors["card_edge"],
+        borderwidth=1,
+        relief="solid",
+        foreground=colors["ink"],
+    )
+    style.configure(
+        "TLabelframe.Label",
+        background=colors["card"],
+        foreground=colors["ink_muted"],
+    )
+
+    style.configure(
+        "Treeview",
+        background=colors["card"],
+        fieldbackground=colors["card"],
+        foreground=colors["ink"],
+        bordercolor=colors["card_edge"],
+    )
+    style.map(
+        "Treeview",
+        background=[("selected", colors["primary_hover"])],
+        foreground=[("selected", colors["on_primary"])],
+    )
+    style.configure(
+        "Treeview.Heading",
+        background=colors["card_edge"],
+        foreground=colors["ink"],
+        bordercolor=colors["card_edge"],
+        relief="flat",
+    )
+    style.map(
+        "Treeview.Heading",
+        background=[("active", colors["primary_hover"])],
+        foreground=[("active", colors["on_primary"])],
+    )
+
+    style.configure("TSeparator", background=colors["card_edge"])
+
+    style.configure(
+        "Vertical.TScrollbar",
+        background=colors["card"],
+        troughcolor=colors["card_edge"],
+        arrowcolor=colors["ink"],
+        bordercolor=colors["card_edge"],
+    )
+    style.configure(
+        "Horizontal.TScrollbar",
+        background=colors["card"],
+        troughcolor=colors["card_edge"],
+        arrowcolor=colors["ink"],
+        bordercolor=colors["card_edge"],
+    )
+
+    style.configure("TPanedwindow", background=colors["bg"], borderwidth=0)
+    style.configure(
+        "Tooltip.TLabel",
+        background=colors["tooltip_bg"],
+        foreground=colors["tooltip_fg"],
+    )
+
+    scope_colors = colors.get("scopes")
+    if isinstance(scope_colors, Mapping):
+        register_scope_styles(style, scope_colors, palette=colors)
+
+
+def register_scope_styles(
+    style: ttk.Style,
+    scope_colors: Mapping[str, str],
+    *,
+    palette: MutableMapping[str, object] | None = None,
+) -> None:  # pragma: no cover - thin wrapper over ttk
+    """Register per-scope button styles on *style*."""
+
+    colors = palette or get_active_palette()
+    if not colors:
+        return
+
+    for scope, color in scope_colors.items():
+        filled = f"Scope.{scope}.TButton"
+        outline = f"Scope.{scope}.Outline.TButton"
+
+        style.configure(
+            filled,
+            background=color,
+            foreground=colors["on_primary"],
+        )
+        style.map(
+            filled,
+            background=[("active", color)],
+            foreground=[("active", colors["on_primary"])],
+        )
+
+        style.configure(
+            outline,
+            background=colors["card"],
+            foreground=color,
+            bordercolor=color,
+            relief="solid",
+            borderwidth=1,
+        )
+        style.map(
+            outline,
+            background=[("active", colors["card"])],
+            foreground=[("active", color)],
+        )
+
+
+__all__ = ["ThemeSpec", "apply_theme", "get_active_palette", "register_scope_styles"]

--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -31,20 +31,25 @@ class SectionFrame(ttk.Frame):  # pragma: no cover - simple container widget
     """Frame grouping field rows for a single section."""
 
     def __init__(self, master: tk.Widget, name: str, *, collapsible: bool, collapsed: bool) -> None:
-        super().__init__(master)
+        super().__init__(master, style="CardSection.TFrame")
         self.name = name
         self._collapsible = collapsible
         self._collapsed = collapsed if collapsible else False
-        header = ttk.Frame(self)
+        header = ttk.Frame(self, style="CardSection.TFrame")
         header.pack(fill="x", padx=(0, 0))
         if collapsible:
-            self._toggle = ttk.Label(header, text="\u25B8" if collapsed else "\u25BE", width=2)
+            self._toggle = ttk.Label(
+                header,
+                text="\u25B8" if collapsed else "\u25BE",
+                width=2,
+                style="CardToggle.TLabel",
+            )
             self._toggle.pack(side="left")
             self._toggle.bind("<Button-1>", lambda e: self.toggle())
         else:
             self._toggle = None
-        ttk.Label(header, text=name, style="Title.TLabel",padding=6).pack(side="left")
-        self.container = ttk.Frame(self)
+        ttk.Label(header, text=name, style="CardSection.TLabel", padding=6).pack(side="left")
+        self.container = ttk.Frame(self, style="CardSection.TFrame")
         if not self._collapsed:
             self.container.pack(fill="x")
 
@@ -209,13 +214,13 @@ class App:
 
     def _style_row(self, row: FieldRow) -> None:
         palette = self.palette
-        row.configure(bg=palette["card"])
-        row.key_frame.configure(style="CardFrame.TFrame")
-        row.lbl_key.configure(background=palette["card"], foreground=palette["ink"])
+        row.configure(bg=palette["card"], highlightthickness=0)
+        row.key_frame.configure(style="CardBody.TFrame")
+        row.lbl_key.configure(style="CardKey.TLabel")
         if row.info_btn:
             row.info_btn.configure(bg=palette["card"], fg=palette["ink_muted"])
         if row.lbl_desc:
-            row.lbl_desc.configure(background=palette["card"], foreground=palette["ink_muted"])
+            row.lbl_desc.configure(style="CardMuted.TLabel")
         row.lbl_eff.configure(
             bg=palette["field"],
             fg=palette["ink"],
@@ -225,7 +230,7 @@ class App:
             bd=0,
             relief="flat",
         )
-        row.pills.configure(style="CardFrame.TFrame")
+        row.pills.configure(style="CardBody.TFrame")
 
     def _populate_providers(self) -> None:
         providers = self.adapter.list_providers()
@@ -279,8 +284,6 @@ class App:
                     collapsible=sec.casefold() in collapsed,
                     collapsed=sec.casefold() in collapsed,
                 )
-                frame.configure(style="CardFrame.TFrame")
-                frame.container.configure(style="CardFrame.TFrame")
                 self.section_frames[sec] = frame
             rows = sorted(groups.get(sec, []), key=field_sort_key)
             for info in rows:

--- a/src/pysigil/ui/tk/author_tools.py
+++ b/src/pysigil/ui/tk/author_tools.py
@@ -109,18 +109,25 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         )
         style.configure(
             "TLabelframe",
-            background=palette["bg"],
-            foreground=palette["hdr_fg"],
+            background=palette["card"],
+            bordercolor=palette["card_edge"],
+            borderwidth=1,
+            relief="solid",
+            foreground=palette["ink"],
         )
         style.configure(
             "TLabelframe.Label",
-            background=palette["bg"],
-            foreground=palette["title_accent"],font=10
+            background=palette["card"],
+            foreground=palette["ink_muted"],
+            font=(None, 10, "bold"),
         )
 
-        #style.configure('TFrame',padding=12)
-
-        style.configure("TLabel",font=(None, 10, "bold"))
+        style.configure(
+            "TLabel",
+            background=palette["bg"],
+            foreground=palette["hdr_fg"],
+            font=(None, 10, "bold"),
+        )
 
         pid = core.state.provider_id or ""
         project_root: Path | None = core.state.project_root
@@ -165,14 +172,14 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         self.geometry("800x600")
         ttk.Label(self, textvariable=self._info_var).pack(anchor="w", padx=6, pady=6)
         pw = ttk.PanedWindow(self, orient="horizontal")
-        self._left = ttk.Frame(pw)
-        self._right = ttk.Frame(pw)
+        self._left = ttk.Frame(pw, style="CardBody.TFrame")
+        self._right = ttk.Frame(pw, style="CardBody.TFrame")
         pw.add(self._left, weight=1)
         pw.add(self._right, weight=3)
         pw.pack(fill="both", expand=True)
 
         # -- left: search + tree -------------------------------------------------
-        search = ttk.Frame(self._left)
+        search = ttk.Frame(self._left, style="CardBody.TFrame")
         search.pack(fill="x", padx=6, pady=(6, 0))
         self._search_var = tk.StringVar()
         entry = ttk.Entry(search, textvariable=self._search_var)
@@ -186,7 +193,7 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         self._tree.bind("<<TreeviewOpen>>", self._on_tree_open)
 
         # -- right: placeholder frame for form -----------------------------------
-        self._form = ttk.Frame(self._right)
+        self._form = ttk.Frame(self._right, style="CardBody.TFrame")
         self._form.pack(fill="both", expand=True, padx=6, pady=6)
 
     # ------------------------------------------------------------------
@@ -607,15 +614,16 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
     # ------------------------------------------------------------------
     def _populate_form(self, info: FieldInfo, default: object | None, *, undiscovered: bool) -> None:
         self._clear_form()
+        palette = get_palette()
 
         # Identity -------------------------------------------------------
         ident = ttk.LabelFrame(self._form, text=" Identity ", padding=(12,8,12,12)) #
         ident.pack(fill="x", pady=(0, 6))
         self._key_var = tk.StringVar(value=info.key)
-        ttk.Label(ident, text="Key: ").grid(row=0, column=0, sticky="w")
+        ttk.Label(ident, text="Key: ", style="Card.TLabel").grid(row=0, column=0, sticky="w")
         ttk.Entry(ident, textvariable=self._key_var).grid(row=0, column=1, sticky="ew")
         self._label_var = tk.StringVar(value=info.label or "")
-        ttk.Label(ident, text="Label: ").grid(row=1, column=0, sticky="w")
+        ttk.Label(ident, text="Label: ", style="Card.TLabel").grid(row=1, column=0, sticky="w")
         ttk.Entry(ident, textvariable=self._label_var).grid(row=1, column=1, sticky="ew")
         ident.columnconfigure(1, weight=1)
 
@@ -623,10 +631,10 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         desc_fr = ttk.LabelFrame(self._form, text=" Descriptions ", padding=(12,8,12,12))
         desc_fr.pack(fill="x", pady=(0, 6))
         self._desc_short_var = tk.StringVar(value=info.description_short or "")
-        ttk.Label(desc_fr, text="Short: ").grid(row=0, column=0, sticky="w")
+        ttk.Label(desc_fr, text="Short: ", style="Card.TLabel").grid(row=0, column=0, sticky="w")
         short_entry = ttk.Entry(desc_fr, textvariable=self._desc_short_var)
         short_entry.grid(row=0, column=1, sticky="ew")
-        self._desc_short_count = ttk.Label(desc_fr, text="0/0")
+        self._desc_short_count = ttk.Label(desc_fr, text="0/0", style="CardMuted.TLabel")
         self._desc_short_count.grid(row=0, column=2, sticky="e")
         desc_fr.columnconfigure(1, weight=1)
 
@@ -638,8 +646,20 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         self._desc_short_var.trace_add("write", _update_count)
         _update_count()
 
-        ttk.Label(desc_fr, text="Long: ").grid(row=1, column=0, sticky="nw")
-        self._desc_text = tk.Text(desc_fr, height=4, wrap="word")
+        ttk.Label(desc_fr, text="Long: ", style="Card.TLabel").grid(row=1, column=0, sticky="nw")
+        self._desc_text = tk.Text(
+            desc_fr,
+            height=4,
+            wrap="word",
+            bg=palette["field"],
+            fg=palette["ink"],
+            insertbackground=palette["ink"],
+            highlightthickness=1,
+            highlightbackground=palette["field_bd"],
+            highlightcolor=palette["primary"],
+            relief="flat",
+            bd=1,
+        )
         self._desc_text.grid(row=1, column=1, columnspan=2, sticky="ew")
         if info.description:
             self._desc_text.insert("1.0", info.description)
@@ -648,7 +668,7 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         type_fr = ttk.LabelFrame(self._form, text=" Type ", padding=(12,8,12,12))
         type_fr.pack(fill="x", pady=(0, 6))
         self._type_var = tk.StringVar(value=info.type)
-        ttk.Label(type_fr, text="Type: ").grid(row=0, column=0, sticky="w")
+        ttk.Label(type_fr, text="Type: ", style="Card.TLabel").grid(row=0, column=0, sticky="w")
         type_combo = ttk.Combobox(
             type_fr,
             textvariable=self._type_var,
@@ -670,17 +690,17 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         group_fr = ttk.LabelFrame(self._form, text=" Grouping ", padding=(12,8,12,12))
         group_fr.pack(fill="x", pady=(0, 6))
         self._section_var = tk.StringVar(value=info.section or "")
-        ttk.Label(group_fr, text="Section: ").grid(row=0, column=0, sticky="w")
+        ttk.Label(group_fr, text="Section: ", style="Card.TLabel").grid(row=0, column=0, sticky="w")
         ttk.Entry(group_fr, textvariable=self._section_var).grid(row=0, column=1, sticky="ew")
         self._order_var = tk.StringVar(
             value="" if info.order is None else str(info.order)
         )
-        ttk.Label(group_fr, text="Order: ").grid(row=1, column=0, sticky="w")
+        ttk.Label(group_fr, text="Order: ", style="Card.TLabel").grid(row=1, column=0, sticky="w")
         ttk.Entry(group_fr, textvariable=self._order_var).grid(row=1, column=1, sticky="ew")
         group_fr.columnconfigure(1, weight=1)
 
         # Actions --------------------------------------------------------
-        actions = ttk.Frame(self._form)
+        actions = ttk.Frame(self._form, style="CardBody.TFrame")
         actions.pack(fill="x", pady=(0, 6))
         ttk.Button(actions, text="Save", command=self._on_save).pack(side="right")
         ttk.Button(actions, text="Revert", command=self._on_revert).pack(side="right")
@@ -698,8 +718,19 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
             style="Toolbutton",
         )
         toggle.pack(anchor="w")
-        self._diff_frame = ttk.Frame(self._form)
-        self._diff_text = tk.Text(self._diff_frame, height=6)
+        self._diff_frame = ttk.Frame(self._form, style="CardBody.TFrame")
+        self._diff_text = tk.Text(
+            self._diff_frame,
+            height=6,
+            bg=palette["field"],
+            fg=palette["ink"],
+            insertbackground=palette["ink"],
+            highlightthickness=1,
+            highlightbackground=palette["field_bd"],
+            highlightcolor=palette["primary"],
+            relief="flat",
+            bd=1,
+        )
         self._diff_text.pack(fill="both", expand=True)
         self._register_form_watchers()
         self._store_field_snapshot()

--- a/src/pysigil/ui/tk/config_gui.py
+++ b/src/pysigil/ui/tk/config_gui.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from tkinter import messagebox, ttk
 
 from ...config import host_id, init_config, open_scope
+from ..aurelia_theme import get_palette, use
 
 
 def _launch(path: Path) -> None:  # pragma: no cover - best effort
@@ -24,8 +25,11 @@ def _launch(path: Path) -> None:  # pragma: no cover - best effort
 
 def launch() -> None:  # pragma: no cover - GUI interactions
     root = tk.Tk()
+    use(root)
+    palette = get_palette()
     root.title("Sigil Config")
-    ttk.Label(root, text=f"Host: {host_id()}").pack(padx=10, pady=10)
+    root.configure(bg=palette["bg"])  # type: ignore[call-arg]
+    ttk.Label(root, text=f"Host: {host_id()}", style="Card.TLabel").pack(padx=10, pady=10)
 
     def do_open() -> None:
         path = open_scope("user-custom", "user")

--- a/src/pysigil/ui/tk/dialogs.py
+++ b/src/pysigil/ui/tk/dialogs.py
@@ -58,10 +58,7 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
         ttk.Label(self, text=label, style="Title.TLabel").pack(
             anchor="w", padx=18, pady=(12, 0)
         )
-        ttk.Style(self).configure(
-            "Key.TLabel", background=palette["bg"], foreground=palette["hdr_muted"]
-        )
-        ttk.Label(self, text=key, style="Key.TLabel").pack(
+        ttk.Label(self, text=key, style="CardMuted.TLabel").pack(
             anchor="w", padx=18, pady=(0, 6)
         )
         body = ttk.Frame(self, padding=12, style="Card.TFrame")
@@ -158,20 +155,22 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
                 btn_remove.state(["disabled"])
 
             if vinfo and vinfo.error:
-                err = ttk.Label(body, text=vinfo.error, foreground="#b91c1c")
+                err = ttk.Label(
+                    body,
+                    text=vinfo.error,
+                    foreground="#b91c1c",
+                    style="Card.TLabel",
+                )
                 err.grid(row=row + 1, column=1, columnspan=3, sticky="w", pady=(0, 4))
                 row += 1
 
             self.entries[scope] = entry
             row += 1
-        ttk.Style(self).configure(
-            "Desc.TLabel", background=palette["card"], foreground=palette["ink_muted"]
-        )
         if info.description_short:
             ttk.Label(
                 body,
                 text=info.description_short,
-                style="Desc.TLabel",
+                style="CardMuted.TLabel",
                 wraplength=400,
                 anchor="w",
                 justify="left",
@@ -181,7 +180,7 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
             ttk.Label(
                 body,
                 text=info.description,
-                style="Desc.TLabel",
+                style="CardMuted.TLabel",
                 wraplength=400,
                 anchor="w",
                 justify="left",

--- a/src/pysigil/ui/tk/list_editor.py
+++ b/src/pysigil/ui/tk/list_editor.py
@@ -42,6 +42,8 @@ except Exception:  # pragma: no cover - fallback when tkinter missing
 import csv
 from io import StringIO
 
+from ..aurelia_theme import get_palette, use
+
 
 Mode = Literal["simple", "kv", "choice"]
 
@@ -82,7 +84,7 @@ class ListEditor(ttk.Frame):  # pragma: no cover - exercised via tk tests
     ) -> None:
         if tk is None:  # pragma: no cover - environment guard
             raise RuntimeError("tkinter is required for ListEditor")
-        super().__init__(master)
+        super().__init__(master, style="CardBody.TFrame")
         self.mode = mode
         self.unique = unique
         self.allow_empty = allow_empty
@@ -101,7 +103,7 @@ class ListEditor(ttk.Frame):  # pragma: no cover - exercised via tk tests
     # UI construction
     # ------------------------------------------------------------------
     def _build(self, columns: Sequence[Column] | None) -> None:
-        toolbar = ttk.Frame(self)
+        toolbar = ttk.Frame(self, style="CardBody.TFrame")
         toolbar.pack(fill="x", padx=2, pady=2)
         ttk.Button(toolbar, text="Add", command=self._on_add).pack(side="left")
         ttk.Button(toolbar, text="Edit", command=self._on_edit).pack(side="left")
@@ -419,15 +421,18 @@ class ListEditDialog(tk.Toplevel):  # pragma: no cover - exercised via tk tests
         if tk is None:  # pragma: no cover - environment guard
             raise RuntimeError("tkinter is required for ListEditDialog")
         super().__init__(parent)
+        use(self)
+        palette = get_palette()
         self.title("Edit List")
         self.transient(parent)
         self.grab_set()
         self.resizable(True, True)
-        body = ttk.Frame(self, padding=6)
+        self.configure(bg=palette["bg"])  # type: ignore[call-arg]
+        body = ttk.Frame(self, padding=6, style="Card.TFrame")
         body.pack(fill="both", expand=True)
         self.editor = ListEditor(body, **kwargs)
         self.editor.pack(fill="both", expand=True)
-        buttons = ttk.Frame(body)
+        buttons = ttk.Frame(body, style="CardBody.TFrame")
         buttons.pack(fill="x", pady=(6, 0))
         ttk.Button(buttons, text="OK", command=self._on_ok).pack(
             side="right", padx=2

--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -44,20 +44,20 @@ class FieldRow(tk.Frame):
         compact: bool = True,
         on_edit_click: Callable[[str], None] | None = None,
     ) -> None:
-        super().__init__(master)
+        palette = get_palette()
+        super().__init__(master, bg=palette["card"], highlightthickness=0)
         self.adapter = adapter
         self.key = key
         self._on_pill_click = on_pill_click
         self._on_edit_click = on_edit_click
         self.compact = compact
 
-        palette = get_palette()
         ink = palette["ink"]
         ink_muted = palette["ink_muted"]
         field = palette["field"]
 
         # container for key + info button
-        self.key_frame = ttk.Frame(self)
+        self.key_frame = ttk.Frame(self, style="CardBody.TFrame")
 
         self.key_frame.grid(row=0, column=0, sticky="w", pady=(6, 0))
 
@@ -68,7 +68,12 @@ class FieldRow(tk.Frame):
             except Exception:
                 info = None
         label = getattr(info, "label", None) or key
-        self.lbl_key = ttk.Label(self.key_frame, text=label,padding=6, font=(None, 10,"bold")) #this controls the labels themselves
+        self.lbl_key = ttk.Label(
+            self.key_frame,
+            text=label,
+            padding=6,
+            style="CardKey.TLabel",
+        )
         self.lbl_key.pack(side="left")
 
         self.info_btn: tk.Label | None = None
@@ -85,6 +90,7 @@ class FieldRow(tk.Frame):
                     text="\u24D8",
                     fg=ink_muted,
                     cursor="question_arrow",
+                    bg=palette["card"],
                     takefocus=1,
                 )
                 self.info_btn.pack(side="left", padx=(4, 0))
@@ -94,7 +100,7 @@ class FieldRow(tk.Frame):
                 self.lbl_desc = ttk.Label(
                     self,
                     text=info.description_short,
-                    foreground=ink_muted,
+                    style="CardMuted.TLabel",
                     wraplength=600,
                     padding=(6,0,0,0) # (left, top, right, bottom)
                 )
@@ -117,7 +123,7 @@ class FieldRow(tk.Frame):
         self.lbl_eff.grid(row=0, column=1, sticky="new", padx=(8, 8), pady=(6, 0))
 
         # container for scope pills
-        self.pills = ttk.Frame(self)
+        self.pills = ttk.Frame(self, style="CardBody.TFrame")
         self.pills.grid(row=0, column=2, sticky="nw", pady=(6, 0))
 
 


### PR DESCRIPTION
## Summary
- add a central theme manager that applies palettes, ttk styles, and scope styles based on a ThemeSpec
- refactor the Aurelia theme to only define its palette, ttk base theme, and delegate application to the manager

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb37f425f88328a03ab93ea24141a6