### PR TITLE
Fix ruff import-order complaints in UI theme modules

### DIFF
--- a/src/pysigil/ui/aurelia_theme.py
+++ b/src/pysigil/ui/aurelia_theme.py
@@ -1,8 +1,15 @@
-from __future__ import annotations
-
 """Aurelia ttk theme palette definitions."""
 
-from typing import Mapping
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from .theme import (
+    ThemeSpec,
+    apply_theme,
+    get_active_palette,
+    register_scope_styles as _register_scope_styles,
+)
 
 try:  # pragma: no cover - importing tkinter is environment dependent
     import tkinter as tk
@@ -10,8 +17,6 @@ try:  # pragma: no cover - importing tkinter is environment dependent
 except Exception:  # pragma: no cover - fallback when tkinter missing
     tk = None  # type: ignore
     ttk = None  # type: ignore
-
-from .theme import ThemeSpec, apply_theme, get_active_palette, register_scope_styles as _register_scope_styles
 
 _AURELIA_PALETTE: dict[str, object] = {
     "bg": "#2B313B",

--- a/src/pysigil/ui/theme.py
+++ b/src/pysigil/ui/theme.py
@@ -1,9 +1,9 @@
-from __future__ import annotations
-
 """Toolkit-agnostic theme management for tkinter UIs."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass
-from typing import Mapping, MutableMapping
 
 try:  # pragma: no cover - importing tkinter is environment dependent
     import tkinter as tk
@@ -21,7 +21,7 @@ class ThemeSpec:
     ttk_theme: str
     palette: Mapping[str, object]
 
-    def with_palette(self, palette: Mapping[str, object]) -> "ThemeSpec":
+    def with_palette(self, palette: Mapping[str, object]) -> ThemeSpec:
         """Return a copy of the theme using *palette* instead of the default."""
 
         return ThemeSpec(name=self.name, ttk_theme=self.ttk_theme, palette=palette)


### PR DESCRIPTION
## Summary
- ensure the module docstrings are first and keep the `__future__` imports directly afterwards in the theme modules
- reorganize the theme imports so they reside above the tkinter try/except block and import `Mapping` from `collections.abc`
- drop the unnecessary quoted forward reference in `ThemeSpec.with_palette`

## Testing
- ruff check src/pysigil/ui/aurelia_theme.py src/pysigil/ui/theme.py --no-fix

------
https://chatgpt.com/codex/tasks/task_e_68cb3e0f53f08328bf8dda5ec8f60374