### PR TITLE
Adjust Aurelia UI backgrounds to match design

### DIFF
--- a/src/pysigil/ui/theme.py
+++ b/src/pysigil/ui/theme.py
@@ -85,9 +85,18 @@ def apply_theme(
         option_add("*activeBackground", colors["primary_hover"])
         option_add("*activeForeground", colors["on_primary"])
         option_add("*highlightColor", colors["gold"])
+        option_add("*TCombobox*Listbox.background", colors["field"])
+        option_add("*TCombobox*Listbox.foreground", colors["ink"])
+        option_add("*TCombobox*Listbox.selectBackground", colors["primary_hover"])
+        option_add("*TCombobox*Listbox.selectForeground", colors["on_primary"])
 
     style.configure("TFrame", background=colors["bg"])
     style.configure("TLabel", background=colors["bg"], foreground=colors["hdr_fg"])
+    style.configure(
+        "Muted.TLabel",
+        background=colors["bg"],
+        foreground=colors["hdr_muted"],
+    )
 
     style.configure(
         "TMenubutton",
@@ -215,6 +224,22 @@ def apply_theme(
         background=colors["card"],
         foreground=colors["ink"],
         font=(None, 12, "bold"),
+    )
+    style.configure("SectionHeader.TFrame", background=colors["bg"])
+    style.configure(
+        "SectionHeader.TLabel",
+        background=colors["bg"],
+        foreground=colors["hdr_fg"],
+        font=(None, 12, "bold"),
+    )
+    style.configure(
+        "SectionHeaderToggle.TLabel",
+        background=colors["bg"],
+        foreground=colors["hdr_muted"],
+    )
+    style.map(
+        "SectionHeaderToggle.TLabel",
+        foreground=[("active", colors["hdr_fg"])],
     )
     style.configure(
         "CardToggle.TLabel",

--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -35,20 +35,22 @@ class SectionFrame(ttk.Frame):  # pragma: no cover - simple container widget
         self.name = name
         self._collapsible = collapsible
         self._collapsed = collapsed if collapsible else False
-        header = ttk.Frame(self, style="CardSection.TFrame")
+        header = ttk.Frame(self, style="SectionHeader.TFrame")
         header.pack(fill="x", padx=(0, 0))
         if collapsible:
             self._toggle = ttk.Label(
                 header,
                 text="\u25B8" if collapsed else "\u25BE",
                 width=2,
-                style="CardToggle.TLabel",
+                style="SectionHeaderToggle.TLabel",
             )
             self._toggle.pack(side="left")
             self._toggle.bind("<Button-1>", lambda e: self.toggle())
         else:
             self._toggle = None
-        ttk.Label(header, text=name, style="CardSection.TLabel", padding=6).pack(side="left")
+        ttk.Label(
+            header, text=name, style="SectionHeader.TLabel", padding=6
+        ).pack(side="left")
         self.container = ttk.Frame(self, style="CardSection.TFrame")
         if not self._collapsed:
             self.container.pack(fill="x")

--- a/src/pysigil/ui/tk/dialogs.py
+++ b/src/pysigil/ui/tk/dialogs.py
@@ -58,7 +58,7 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
         ttk.Label(self, text=label, style="Title.TLabel").pack(
             anchor="w", padx=18, pady=(12, 0)
         )
-        ttk.Label(self, text=key, style="CardMuted.TLabel").pack(
+        ttk.Label(self, text=key, style="Muted.TLabel").pack(
             anchor="w", padx=18, pady=(0, 6)
         )
         body = ttk.Frame(self, padding=12, style="Card.TFrame")
@@ -139,14 +139,12 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
                 body,
                 text="Save",
                 command=lambda s=scope: self._save_scope(s),
-                style="Plain.TButton",
             )
             btn_save.grid(row=row, column=2, padx=4)
             btn_remove = ttk.Button(
                 body,
                 text="Remove",
                 command=lambda s=scope: self._remove_scope(s),
-                style="Plain.TButton",
             )
             btn_remove.grid(row=row, column=3, padx=4)
 
@@ -187,9 +185,9 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
             ).grid(row=row, column=0, columnspan=4, sticky="w")
             row += 1
 
-        ttk.Button(
-            body, text="Close", command=self.destroy, style="Plain.TButton"
-        ).grid(row=row, column=3, sticky="e")
+        ttk.Button(body, text="Close", command=self.destroy).grid(
+            row=row, column=3, sticky="e"
+        )
         body.columnconfigure(1, weight=1)
 
     # -- callbacks ---------------------------------------------------------

--- a/src/pysigil/ui/tk/widgets.py
+++ b/src/pysigil/ui/tk/widgets.py
@@ -153,6 +153,7 @@ class PillButton(tk.Canvas):
         self.configure(width=w)
         self.delete("all")
         palette = get_palette()
+        self.configure(bg=palette["card"])
         card = palette["card"]
         card_edge = palette["card_edge"]
         ink_muted = palette["ink_muted"]


### PR DESCRIPTION
## Summary
- ensure Aurelia combobox dropdowns and new muted labels use the light field background
- restore the dark section header styling and align pill canvases with the surrounding card color
- give edit dialog controls the default bordered buttons for consistency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb3f5b41188328b19236927d8874d8