### PR TITLE
Adjust author tools theming for dark background

### DIFF
--- a/src/pysigil/ui/options_form.py
+++ b/src/pysigil/ui/options_form.py
@@ -35,7 +35,7 @@ class OptionsForm(ttk.Frame):
     def __init__(self, master, field_type: str | FieldType) -> None:
         if tk is None or ttk is None:  # pragma: no cover - tkinter missing
             raise RuntimeError("tkinter is required for OptionsForm")
-        super().__init__(master)
+        super().__init__(master, style="CardBody.TFrame")
         self._ft = TYPE_REGISTRY[field_type] if isinstance(field_type, str) else field_type
         self._option_model = self._ft.option_model
         self._widgets: dict[str, EditorWidget] = {}
@@ -58,7 +58,7 @@ class OptionsForm(ttk.Frame):
             if ft.value_widget is None:
                 raise TypeError(f"no widget for option field type {key}")
             widget = ft.value_widget(self)  # type: ignore[assignment]
-            label = ttk.Label(self, text=f.name.replace("_", " "))
+            label = ttk.Label(self, text=f.name.replace("_", " "), style="Card.TLabel")
             label.grid(row=row, column=0, sticky="w", padx=4, pady=2)
             widget.grid(row=row, column=1, sticky="ew", padx=4, pady=2)
             self._widgets[f.name] = widget

--- a/src/pysigil/ui/theme.py
+++ b/src/pysigil/ui/theme.py
@@ -160,6 +160,21 @@ def apply_theme(
     )
 
     style.configure(
+        "Card.TRadiobutton",
+        background=colors["card"],
+        foreground=colors["ink"],
+        indicatorcolor=colors["card_edge"],
+        focusthickness=1,
+        focuscolor=colors["primary"],
+    )
+    style.map(
+        "Card.TRadiobutton",
+        foreground=[("disabled", colors["ink_muted"]), ("active", colors["ink"])],
+        indicatorcolor=[("selected", colors["primary"]), ("!selected", colors["card_edge"])],
+        background=[("active", colors["card_edge"])],
+    )
+
+    style.configure(
         "TRadiobutton",
         background=colors["bg"],
         foreground=colors["hdr_muted"],

--- a/src/pysigil/ui/tk/author_tools.py
+++ b/src/pysigil/ui/tk/author_tools.py
@@ -172,8 +172,8 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         self.geometry("800x600")
         ttk.Label(self, textvariable=self._info_var).pack(anchor="w", padx=6, pady=6)
         pw = ttk.PanedWindow(self, orient="horizontal")
-        self._left = ttk.Frame(pw, style="CardBody.TFrame")
-        self._right = ttk.Frame(pw, style="CardBody.TFrame")
+        self._left = ttk.Frame(pw, style="TFrame")
+        self._right = ttk.Frame(pw, style="TFrame")
         pw.add(self._left, weight=1)
         pw.add(self._right, weight=3)
         pw.pack(fill="both", expand=True)
@@ -193,7 +193,7 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         self._tree.bind("<<TreeviewOpen>>", self._on_tree_open)
 
         # -- right: placeholder frame for form -----------------------------------
-        self._form = ttk.Frame(self._right, style="CardBody.TFrame")
+        self._form = ttk.Frame(self._right, style="TFrame")
         self._form.pack(fill="both", expand=True, padx=6, pady=6)
 
     # ------------------------------------------------------------------

--- a/src/pysigil/ui/widgets.py
+++ b/src/pysigil/ui/widgets.py
@@ -36,10 +36,10 @@ class EditorWidget(Protocol):
 def _simple_entry(master) -> EditorWidget:
     if tk is None or ttk is None:  # pragma: no cover - tkinter missing
         raise RuntimeError("tkinter is required for widgets")
-    frame = ttk.Frame(master)
+    frame = ttk.Frame(master, style="CardBody.TFrame")
     entry = ttk.Entry(frame)
     entry.pack(side="left", fill="x", expand=True)
-    badge = ttk.Label(frame, text="")
+    badge = ttk.Label(frame, text="", style="CardMuted.TLabel")
     badge.pack(side="left", padx=4)
 
     def get_value() -> object | None:
@@ -70,14 +70,14 @@ def _simple_entry(master) -> EditorWidget:
 def _boolean_tristate(master) -> EditorWidget:
     if tk is None or ttk is None:  # pragma: no cover - tkinter missing
         raise RuntimeError("tkinter is required for widgets")
-    frame = ttk.Frame(master)
+    frame = ttk.Frame(master, style="CardBody.TFrame")
     var = tk.StringVar(value="unset")
-    btns = ttk.Frame(frame)
+    btns = ttk.Frame(frame, style="CardBody.TFrame")
     btns.pack(side="left")
-    ttk.Radiobutton(btns, text="True", variable=var, value="true").pack(side="left")
-    ttk.Radiobutton(btns, text="False", variable=var, value="false").pack(side="left")
-    ttk.Radiobutton(btns, text="Unset", variable=var, value="unset").pack(side="left")
-    badge = ttk.Label(frame, text="")
+    ttk.Radiobutton(btns, text="True", variable=var, value="true", style="Card.TRadiobutton").pack(side="left")
+    ttk.Radiobutton(btns, text="False", variable=var, value="false", style="Card.TRadiobutton").pack(side="left")
+    ttk.Radiobutton(btns, text="Unset", variable=var, value="unset", style="Card.TRadiobutton").pack(side="left")
+    badge = ttk.Label(frame, text="", style="CardMuted.TLabel")
     badge.pack(side="left", padx=4)
 
     def get_value() -> object | None:


### PR DESCRIPTION
## Summary
- ensure the author tools panes use the dark theme background outside the light cards
- give default value editors and options forms card-aware styles so their controls render on the light surfaces
- add a Card.TRadiobutton theme variant for boolean editors inside light panels

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb418ccbcc8328b6cfe8e7b5d01171