### PR TITLE
Handle invalid conversions when editing fields

### DIFF
--- a/src/pysigil/api.py
+++ b/src/pysigil/api.py
@@ -61,8 +61,16 @@ class FieldInfo:
 @dataclass(frozen=True)
 class ValueInfo:
     value: Any | None
-    source: Literal["user", "user-local", "project", "project-local", "env"] | None
+    source: Literal[
+        "user",
+        "user-local",
+        "project",
+        "project-local",
+        "default",
+        "env",
+    ] | None
     raw: str | None
+    error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -104,7 +112,7 @@ def _provider_info(spec: ProviderSpec) -> ProviderInfo:
 
 
 def _value_info(val: FieldValue) -> ValueInfo:
-    return ValueInfo(value=val.value, source=val.source, raw=val.raw)
+    return ValueInfo(value=val.value, source=val.source, raw=val.raw, error=val.error)
 
 
 # ---------------------------------------------------------------------------

--- a/src/pysigil/ui/provider_adapter.py
+++ b/src/pysigil/ui/provider_adapter.py
@@ -142,7 +142,7 @@ class ProviderAdapter:
         for scope, val in per_scope.items():
             if val is None:
                 continue
-            result[scope] = ValueInfo(value=val.value, error=None)
+            result[scope] = ValueInfo(value=val.value, error=val.error)
         return result
 
     def effective_for_key(self, key: str) -> Tuple[Any | None, str | None]:


### PR DESCRIPTION
## Summary
- add an error slot to `FieldValue` and capture parse failures when reading configuration
- expose parsing errors through the public API and keep raw text when edit-field conversions fail
- surface errors to the UI adapter and cover the regression with an orchestrator test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef94b57788328a9b5c5d427e21e45