### PR TITLE
Surface invalid provider values in UI

### DIFF
--- a/src/pysigil/ui/tk/author_tools.py
+++ b/src/pysigil/ui/tk/author_tools.py
@@ -576,7 +576,12 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         default: object | None = None
         undiscovered = False
         if info is not None:
-            default = self.adapter.default_for_key(key)
+            default_info = self.adapter.default_for_key(key)
+            if default_info is not None:
+                if default_info.error and default_info.raw is not None:
+                    default = default_info.raw
+                else:
+                    default = default_info.value
         else:
             und = {u.key: u for u in self.adapter.list_undiscovered()}
             uinfo = und.get(key)
@@ -864,7 +869,11 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         info = defined.get(key)
         default_val = self.adapter.default_for_key(key)
         if info is not None:
-            self._populate_form(info, default_val, undiscovered=False)
+            if default_val is not None and default_val.error and default_val.raw is not None:
+                default_display = default_val.raw
+            else:
+                default_display = None if default_val is None else default_val.value
+            self._populate_form(info, default_display, undiscovered=False)
         if target is not None:
             self._select_tree_iid(target)
         return True
@@ -876,7 +885,13 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         if self._current_key is not None:
             defined = {f.key: f for f in self.adapter.list_defined()}
             info = defined.get(self._current_key)
-            default = self.adapter.default_for_key(self._current_key)
+            default_info = self.adapter.default_for_key(self._current_key)
+            if default_info is not None and default_info.error and default_info.raw is not None:
+                default = default_info.raw
+            elif default_info is not None:
+                default = default_info.value
+            else:
+                default = None
             if info is not None:
                 self._populate_form(info, default, undiscovered=False)
 
@@ -907,7 +922,13 @@ class AuthorTools(tk.Toplevel):  # pragma: no cover - simple UI wrapper
         self._reload_tree()
         defined = {f.key: f for f in self.adapter.list_defined()}
         info = defined.get(key)
-        default = self.adapter.default_for_key(key)
+        default_info = self.adapter.default_for_key(key)
+        if default_info is not None and default_info.error and default_info.raw is not None:
+            default = default_info.raw
+        elif default_info is not None:
+            default = default_info.value
+        else:
+            default = None
         if info is not None:
             self._populate_form(info, default, undiscovered=False)
         if target is not None:

--- a/tests/test_field_row.py
+++ b/tests/test_field_row.py
@@ -63,10 +63,10 @@ class DummyAdapter:
         }
 
     def effective_for_key(self, key):
-        return "u", "user"
+        return ValueInfo("u"), "user"
 
     def default_for_key(self, key):
-        return "d"
+        return ValueInfo("d")
 
     def scope_hint(self, scope_id):
         if scope_id == "default":
@@ -151,7 +151,7 @@ class NoDefaultAdapter(DummyAdapter):
         return {"env": ValueInfo("e")}
 
     def effective_for_key(self, key):
-        return "e", "env"
+        return ValueInfo("e"), "env"
 
     def default_for_key(self, key):
         return None
@@ -192,7 +192,7 @@ class DefaultOnlyAdapter(DummyAdapter):
         return {"default": ValueInfo("d")}
 
     def effective_for_key(self, key):
-        return "d", "default"
+        return ValueInfo("d"), "default"
 
 
 def test_field_row_default_effective():

--- a/tests/ui/test_edit_dialog.py
+++ b/tests/ui/test_edit_dialog.py
@@ -23,6 +23,12 @@ class DummyAdapter:
     def values_for_key(self, key):
         return {"default": ValueInfo("d")}
 
+    def effective_for_key(self, key):
+        return ValueInfo("d"), "default"
+
+    def default_for_key(self, key):
+        return ValueInfo("d")
+
     def can_write(self, scope):
         return scope != "default"
 

--- a/tests/ui/test_provider_adapter.py
+++ b/tests/ui/test_provider_adapter.py
@@ -40,18 +40,18 @@ def test_adapter_writes_and_effective(tmp_path, monkeypatch):
     assert adapter.provider_sections_collapsed() is None
 
     adapter.set_value("alpha", "user", 1)
-    eff_val, eff_scope = adapter.effective_for_key("alpha")
-    assert eff_val == 1
+    eff_info, eff_scope = adapter.effective_for_key("alpha")
+    assert eff_info is not None and eff_info.value == 1
     assert eff_scope == "user"
 
     adapter.set_value("alpha", "project", 2)
-    eff_val, eff_scope = adapter.effective_for_key("alpha")
-    assert eff_val == 2
+    eff_info, eff_scope = adapter.effective_for_key("alpha")
+    assert eff_info is not None and eff_info.value == 2
     assert eff_scope == "project"
 
     adapter.clear_value("alpha", "project")
-    eff_val, eff_scope = adapter.effective_for_key("alpha")
-    assert eff_val == 1
+    eff_info, eff_scope = adapter.effective_for_key("alpha")
+    assert eff_info is not None and eff_info.value == 1
     assert eff_scope == "user"
 
 


### PR DESCRIPTION
## Summary
- propagate raw text and error details through ProviderAdapter value lookups
- surface invalid values in the Tk rows/edit dialogs and adjust author tools to consume the richer data
- expand UI tests to cover error propagation from provider adapter

## Testing
- pytest tests/test_author_mode.py tests/ui/test_provider_adapter.py tests/test_field_row.py tests/ui/test_edit_dialog.py tests/test_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cefb23c71483288a4202a1ef4558f0