### PR TITLE
Adjust Tk theme hover states and app geometry

### DIFF
--- a/src/pysigil/ui/theme.py
+++ b/src/pysigil/ui/theme.py
@@ -142,6 +142,7 @@ def apply_theme(
         "TCheckbutton",
         foreground=[("disabled", colors["ink_muted"]), ("active", colors["hdr_fg"])],
         indicatorcolor=[("selected", colors["primary"]), ("!selected", colors["card_edge"])],
+        background=[("active", colors["bg"]), ("pressed", colors["bg"])],
     )
 
     style.configure(
@@ -156,7 +157,7 @@ def apply_theme(
         "Card.TCheckbutton",
         foreground=[("disabled", colors["ink_muted"]), ("active", colors["ink"])],
         indicatorcolor=[("selected", colors["primary"]), ("!selected", colors["card_edge"])],
-        background=[("active", colors["card_edge"])],
+        background=[("active", colors["card"]), ("pressed", colors["card"])],
     )
 
     style.configure(
@@ -171,7 +172,7 @@ def apply_theme(
         "Card.TRadiobutton",
         foreground=[("disabled", colors["ink_muted"]), ("active", colors["ink"])],
         indicatorcolor=[("selected", colors["primary"]), ("!selected", colors["card_edge"])],
-        background=[("active", colors["card_edge"])],
+        background=[("active", colors["card"]), ("pressed", colors["card"])],
     )
 
     style.configure(
@@ -186,6 +187,7 @@ def apply_theme(
         "TRadiobutton",
         foreground=[("disabled", colors["ink_muted"]), ("active", colors["hdr_fg"])],
         indicatorcolor=[("selected", colors["primary"]), ("!selected", colors["card_edge"])],
+        background=[("active", colors["bg"]), ("pressed", colors["bg"])],
     )
 
     style.configure(

--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -95,6 +95,7 @@ class App:
         if tk is None:  # pragma: no cover - environment without tkinter
             raise RuntimeError("tkinter is required for App")
 
+        owns_root = master is None
         self.root = master if master is not None else tk.Tk()
         self.adapter = adapter or ProviderAdapter(author_mode=author_mode)
         self.events = events or EventBus()
@@ -114,6 +115,10 @@ class App:
         self._rows_scrollbar: ttk.Scrollbar | None = None
         self._rows_window: int | None = None
         self._mousewheel_bound = False
+
+        if owns_root:
+            self.root.geometry("1200x760")
+            self.root.minsize(960, 640)
 
         use(self.root)
         self.palette = get_palette()

--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -123,6 +123,7 @@ class FieldRow(tk.Frame):
         self.lbl_eff.grid(row=0, column=1, sticky="new", padx=(8, 8), pady=(6, 0))
         self._eff_fg_normal = ink
         self._eff_fg_error = "#b91c1c"
+        self._value_pad: int | None = None
 
         # container for scope pills
         self.pills = ttk.Frame(self, style="CardBody.TFrame")
@@ -249,10 +250,15 @@ class FieldRow(tk.Frame):
             self.update_idletasks()
             btn_h = self.btn_edit.winfo_height()
             lbl_h = self.lbl_eff.winfo_height()
-            diff = btn_h - lbl_h
-            if diff > 0:
-                pad = (diff+1) // 5
-                self.lbl_eff.configure(pady=pad)
+            if btn_h <= 0 or lbl_h <= 0:
+                return
+            if self._value_pad is None:
+                diff = btn_h - lbl_h
+                pad = (diff + 1) // 5 if diff > 0 else 0
+                if pad < 0:
+                    pad = 0
+                self._value_pad = pad
+            self.lbl_eff.configure(pady=self._value_pad)
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- prevent checkbuttons and radiobuttons from flashing white on hover by mapping hover backgrounds to theme colors
- stabilize the effective value display padding so the box height no longer jumps after edits
- enlarge the default Tk window and establish a larger minimum size for the scrolling layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf02fe8048832897c8a48219daac63