### PR TITLE
Add confirmations to author tools deletes and fix default handling

### DIFF
--- a/src/pysigil/ui/author_adapter.py
+++ b/src/pysigil/ui/author_adapter.py
@@ -45,6 +45,7 @@ class ValueInfo:
     raw: str | None
     scope: str | None = None
     value: Any | None = None
+    error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -158,14 +159,16 @@ class AuthorAdapter:
             infos.append(UntrackedInfo(key=key, raw=raw, guessed_type=guessed))
         return infos
 
-    def default_for_key(self, key: str) -> Any | None:
-        """Return the value from the ``default`` scope for *key*."""
+    def default_for_key(self, key: str) -> ValueInfo | None:
+        """Return value information from the ``default`` scope for *key*."""
 
         handle = self._require_handle()
         layers = handle.layers()
         per_scope = layers.get(key, {})
         val = per_scope.get("default")
-        return None if val is None else val.value
+        if val is None:
+            return None
+        return ValueInfo(raw=val.raw, scope="default", value=val.value, error=val.error)
 
     def get_sections_order(self) -> list[str] | None:
         handle = self._require_handle()

--- a/tests/test_author_adapter.py
+++ b/tests/test_author_adapter.py
@@ -21,7 +21,8 @@ def test_upsert_field_sets_options_and_default(tmp_path, monkeypatch):
 
     fields = {f.key: f for f in adapter.list_defined()}
     assert fields["alpha"].options == {"minimum": 0}
-    assert adapter.default_for_key("alpha") == 5
+    default_info = adapter.default_for_key("alpha")
+    assert default_info is not None and default_info.value == 5
 
 
 def test_adopt_untracked(tmp_path, monkeypatch):

--- a/tests/test_author_mode.py
+++ b/tests/test_author_mode.py
@@ -97,4 +97,5 @@ def test_upsert_field_parses_default(tmp_path, monkeypatch):
     with pytest.raises(ValidationError):
         author.upsert_field("beta", "integer", default="1")
     author.upsert_field("beta", "integer", default=parse_field_value("integer", "1"))
-    assert author.default_for_key("beta") == 1
+    default_info = author.default_for_key("beta")
+    assert default_info is not None and default_info.value == 1


### PR DESCRIPTION
## Summary
- return rich value information for default scope queries in the author adapter
- add confirmation prompts and shared display helpers in the author tools UI
- update tests to reflect the new default value contract

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf068c5c788328abb198c1922604d9