### PR TITLE
Remember last provider selection in GUI

### DIFF
--- a/src/pysigil/cli.py
+++ b/src/pysigil/cli.py
@@ -208,7 +208,11 @@ def export_cmd(args: argparse.Namespace) -> int:
 
 
 def gui_cmd(args: argparse.Namespace) -> int:  # pragma: no cover - GUI interactions
-    launch_gui(initial_provider=args.app, author_mode=author_mode_enabled(args))
+    launch_gui(
+        initial_provider=args.app,
+        author_mode=author_mode_enabled(args),
+        remember=not getattr(args, "no_remember", False),
+    )
     return 0
 
 

--- a/src/pysigil/ui/state.py
+++ b/src/pysigil/ui/state.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ..paths import user_data_dir
+
+
+def gui_state_file() -> Path:
+    """Return the path storing per-user GUI state."""
+
+    return user_data_dir() / "gui-state.json"
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        return {}
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def load_last_provider() -> str | None:
+    """Return the last provider selected in the GUI, if available."""
+
+    state = _load_state(gui_state_file())
+    value = state.get("last_provider")
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def save_last_provider(provider_id: str) -> None:
+    """Persist *provider_id* as the last provider selected in the GUI."""
+
+    if not provider_id:
+        return
+    path = gui_state_file()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        state = _load_state(path)
+        state["last_provider"] = provider_id
+        path.write_text(json.dumps(state))
+    except Exception:
+        # Persistence failures are non-fatal for the GUI.
+        return
+
+
+__all__ = ["gui_state_file", "load_last_provider", "save_last_provider"]


### PR DESCRIPTION
## Summary
- persist the GUI's last selected provider in a user data file and reuse it on startup
- update the Tk App and CLI to respect the persisted provider and offer an opt-out flag
- cover the new behaviour with Tk App tests that mock the state file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf080ce1108328a935896b9f3e438a