### PR TITLE
Revise GUI reference for new layout guidance

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -1,4 +1,4 @@
-# Launching the Preferences GUI
+# Preferences GUI Overview
 
 Sigil ships with a small Tk based GUI for editing user preferences. Install with
 `pip install sigil[gui]` and run:
@@ -17,19 +17,41 @@ launch(initial_provider="myapp")
 
 This opens a window showing all user-level preferences defined for *myapp*.
 
-## Debug logging
+## Layout essentials
 
-Set the environment variable `SIGIL_GUI_DEBUG=1` before launching the GUI to
-emit verbose debug information to the console.  This can help diagnose problems
-with package loading or preference updates and can be disabled by unsetting the
-variable.
+* Use regular list bullets for scope selectors; keep the glyphs crisp and
+  aligned so the eye can scan down the stack quickly.
+* Attach short tooltips to each bullet describing when that scope becomes the
+  effective value.
+* Keep the entire layout within a single view—avoid modal "smart navigation"
+  hops so users can compare scopes at a glance.
+
+## Effective, active, and missing values
+
+The GUI highlights three states for every preference value:
+
+* **Effective** – the value that will be read by clients.
+* **Active** – the highest‑precedence scope that currently defines a value.
+* **Missing** – scopes that do not define a value.
+
+Example: a `timeout` preference across user, workspace, and machine scopes.
+
+| Scope     | Value | Status                                    |
+|-----------|-------|-------------------------------------------|
+| User      | 45    | Effective and active (highest precedence) |
+| Workspace | 60    | Present but inactive (overridden)         |
+| Machine   | —     | Missing – inherits from higher scopes     |
+
+When the user clears their value, the workspace entry becomes both active and
+effective. Tooltips for each bullet echo the same explanation so users can
+understand the transition without consulting documentation.
 
 ## Adapter boundary and scope handling
 
 The GUI communicates with the core only through the
-[`ProviderAdapter`](../src/pysigil/ui/provider_adapter.py).  Widgets ask the
+[`ProviderAdapter`](../src/pysigil/ui/provider_adapter.py). Widgets ask the
 adapter which scopes to render, obtain human‑readable labels, and read or write
-values.  This separation keeps toolkit code decoupled from `pysigil.api`.
+values. This separation keeps toolkit code decoupled from `pysigil.api`.
 
 ```python
 from pysigil.ui.provider_adapter import ProviderAdapter
@@ -40,18 +62,17 @@ for scope in adapter.scopes():
     print(adapter.scope_label(scope, short=True), adapter.can_write(scope))
 ```
 
-Toolkit components can mirror the prototype’s pill behaviour by wiring the
-adapter into callbacks:
+Widgets render one bullet per scope and wire callbacks through the adapter:
 
 ```python
 from pysigil.ui.tk.rows import FieldRow
 
-def on_pill_click(key: str, scope: str) -> None:
+def on_scope_selected(key: str, scope: str) -> None:
     adapter.set_value(key, scope, "42")
 
-row = FieldRow(parent, adapter, "alpha", on_pill_click)
+row = FieldRow(parent, adapter, "alpha", on_scope_selected)
 ```
 
-Each pill invokes `on_pill_click` with its scope, allowing dialogs or other
-widgets to focus edits to that layer while the adapter manages precedence and
-scope visibility.
+Each selection invokes `on_scope_selected` with its scope, allowing dialogs or
+other widgets to focus edits to that layer while the adapter manages precedence
+and scope visibility.

--- a/src/pysigil/ui/static/quick_reference.html
+++ b/src/pysigil/ui/static/quick_reference.html
@@ -44,59 +44,32 @@
     <main class="mx-auto flex max-w-5xl flex-col gap-8 px-6 py-12">
       <header class="rounded-2xl bg-aurora-card/95 p-8 shadow-xl shadow-black/30">
         <p class="text-sm font-semibold uppercase tracking-widest text-aurora-inkMuted">pysigil quick reference</p>
-        <h1 class="mt-2 text-4xl font-bold text-aurora-ink">Configure settings with confidence</h1>
+        <h1 class="mt-2 text-4xl font-bold text-aurora-ink">Key controls at a glance</h1>
         <p class="mt-4 max-w-3xl text-lg text-aurora-inkMuted">
-          Use this page as a concise guide when navigating the pysigil preferences GUI. Each
-          section highlights the essential actions and visual cues you will encounter.
+          Use this single-page guide when navigating the pysigil preferences GUI. Each section highlights the
+          essential actions and visual cues you will encounter.
         </p>
       </header>
 
       <section class="grid gap-6 lg:grid-cols-2">
         <article class="rounded-2xl border border-aurora-edge/60 bg-aurora-card/95 p-6 shadow-lg shadow-black/20">
           <h2 class="text-xl font-semibold text-aurora-ink">Getting oriented</h2>
-          <ul class="mt-4 space-y-3 text-aurora-inkMuted">
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-gold"></span>
-              <span><span class="font-medium text-aurora-ink">Provider</span> selects the definition set to inspect. The dropdown remembers your last choice.</span>
-            </li>
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-gold"></span>
-              <span><span class="font-medium text-aurora-ink">Compact</span> toggles between condensed pills and a spacious layout for easier reading.</span>
-            </li>
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-gold"></span>
-              <span>The <span class="font-medium text-aurora-ink">Project</span> field shows which project path is contributing overrides (read-only).</span>
-            </li>
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-gold"></span>
-              <span><span class="font-medium text-aurora-ink">Author Tools…</span> (author mode only) opens dialogs for editing metadata such as sections and defaults.</span>
-            </li>
+          <ul class="mt-4 list-disc space-y-2 pl-6 text-aurora-inkMuted">
+            <li><span class="font-medium text-aurora-ink">Provider</span> selects the definition set to inspect. The dropdown remembers your last choice.</li>
+            <li><span class="font-medium text-aurora-ink">Compact</span> toggles between a condensed view and a spacious layout for easier reading.</li>
+            <li>The <span class="font-medium text-aurora-ink">Project</span> field shows which project path is contributing overrides (read-only).</li>
+            <li><span class="font-medium text-aurora-ink">Author Tools…</span> (author mode only) opens dialogs for editing metadata such as sections and defaults.</li>
           </ul>
         </article>
 
         <article class="rounded-2xl border border-aurora-edge/60 bg-aurora-card/95 p-6 shadow-lg shadow-black/20">
           <h2 class="text-xl font-semibold text-aurora-ink">Working with fields</h2>
-          <ul class="mt-4 space-y-3 text-aurora-inkMuted">
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-primary"></span>
-              <span>Hover the <span class="font-medium text-aurora-ink">ℹ</span> icon to read the field description and see the tuple-key backing the value.</span>
-            </li>
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-primary"></span>
-              <span>The <span class="font-medium text-aurora-ink">Effective value</span> chip shows what currently applies and which scope provided it. Errors are highlighted in red.</span>
-            </li>
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-primary"></span>
-              <span>Pills display every scope. A solid pill marks the active source; outlined pills hold values that are overridden; muted pills are empty.</span>
-            </li>
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-primary"></span>
-              <span>Click any writable pill to focus that layer when editing. Locked scopes display a padlock cursor and ignore clicks.</span>
-            </li>
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-primary"></span>
-              <span>Use <span class="font-medium text-aurora-ink">Edit…</span> to open the scoped editor. Validation feedback appears immediately.</span>
-            </li>
+          <ul class="mt-4 list-disc space-y-2 pl-6 text-aurora-inkMuted">
+            <li>Hover the <span class="font-medium text-aurora-ink">ℹ</span> icon to read the field description, see the tuple-key backing the value, and preview tooltip notes.</li>
+            <li>The <span class="font-medium text-aurora-ink">Effective value</span> chip shows what currently applies and which scope provided it. Errors are highlighted in red.</li>
+            <li>Pills display every scope. A solid pill marks the active source; outlined pills hold values that are overridden; muted pills are empty.</li>
+            <li>Click any writable pill to focus that layer when editing. Locked scopes display a padlock cursor and ignore clicks.</li>
+            <li>Use <span class="font-medium text-aurora-ink">Edit…</span> to open the scoped editor. Validation feedback appears immediately.</li>
           </ul>
         </article>
       </section>
@@ -159,41 +132,63 @@
         </dl>
       </section>
 
-      <section class="grid gap-6 lg:grid-cols-2">
-        <article class="rounded-2xl border border-aurora-edge/60 bg-aurora-card/95 p-6 shadow-lg shadow-black/20">
-          <h2 class="text-xl font-semibold text-aurora-ink">Smart navigation</h2>
-          <ul class="mt-4 space-y-3 text-aurora-inkMuted">
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-primaryHover"></span>
-              <span>Collapse or expand sections to focus on related fields. The app remembers per-session state.</span>
-            </li>
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-primaryHover"></span>
-              <span>Use the keyboard: Tab between pills, press <kbd class="rounded bg-aurora-surface px-1">Space</kbd> or <kbd class="rounded bg-aurora-surface px-1">Enter</kbd> to activate focused pills.</span>
-            </li>
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-primaryHover"></span>
-              <span>Tooltips summarise values and validation issues without opening dialogs.</span>
-            </li>
-          </ul>
-        </article>
-        <article class="rounded-2xl border border-aurora-edge/60 bg-aurora-card/95 p-6 shadow-lg shadow-black/20">
-          <h2 class="text-xl font-semibold text-aurora-ink">Troubleshooting</h2>
-          <ul class="mt-4 space-y-3 text-aurora-inkMuted">
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-inkMuted"></span>
-              <span>Red text inside the effective chip indicates validation errors. Open <span class="font-medium text-aurora-ink">Edit…</span> to review details.</span>
-            </li>
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-inkMuted"></span>
-              <span>Pills labelled <span class="font-medium text-aurora-ink">synthetic</span> show computed values that cannot be edited.</span>
-            </li>
-            <li class="flex gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-aurora-inkMuted"></span>
-              <span>Enable the <code class="rounded bg-aurora-surface px-1 py-0.5">SIGIL_GUI_DEBUG</code> environment variable before launch for verbose logging.</span>
-            </li>
-          </ul>
-        </article>
+      <section class="rounded-2xl border border-aurora-edge/60 bg-aurora-card/95 p-6 shadow-lg shadow-black/20">
+        <h2 class="text-xl font-semibold text-aurora-ink">Effective, active &amp; missing examples</h2>
+        <p class="mt-2 text-aurora-inkMuted">
+          Match the pills you see with these real values. The <span class="font-medium text-aurora-ink">Effective value</span>
+          chip should line up with the active source in the second column.
+        </p>
+        <div class="mt-4 overflow-x-auto">
+          <table class="w-full min-w-[36rem] border-collapse text-sm text-aurora-inkMuted">
+            <thead class="bg-aurora-surface/60 text-aurora-ink">
+              <tr>
+                <th class="border-b border-aurora-edge/60 px-3 py-2 text-left font-semibold">Field</th>
+                <th class="border-b border-aurora-edge/60 px-3 py-2 text-left font-semibold">Effective</th>
+                <th class="border-b border-aurora-edge/60 px-3 py-2 text-left font-semibold">Present but overridden</th>
+                <th class="border-b border-aurora-edge/60 px-3 py-2 text-left font-semibold">Empty</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="border-b border-aurora-edge/40 px-3 py-2 align-top"><code class="text-aurora-ink">logs.level</code></td>
+                <td class="border-b border-aurora-edge/40 px-3 py-2 align-top"><span class="font-medium text-aurora-ink">Project</span> &rarr; <code>warning</code></td>
+                <td class="border-b border-aurora-edge/40 px-3 py-2 align-top"><span class="font-medium text-aurora-ink">Default</span> &rarr; <code>info</code></td>
+                <td class="border-b border-aurora-edge/40 px-3 py-2 align-top">Environment, User, Machine, Project &middot; Machine</td>
+              </tr>
+              <tr>
+                <td class="border-b border-aurora-edge/40 px-3 py-2 align-top"><code class="text-aurora-ink">editor.theme</code></td>
+                <td class="border-b border-aurora-edge/40 px-3 py-2 align-top"><span class="font-medium text-aurora-ink">User</span> &rarr; <code>aurora-dark</code></td>
+                <td class="border-b border-aurora-edge/40 px-3 py-2 align-top">
+                  <div class="space-y-1">
+                    <div><span class="font-medium text-aurora-ink">Project</span> &rarr; <code>aurora-light</code></div>
+                    <div><span class="font-medium text-aurora-ink">Default</span> &rarr; <code>classic</code></div>
+                  </div>
+                </td>
+                <td class="border-b border-aurora-edge/40 px-3 py-2 align-top">Environment, Machine, Project &middot; Machine</td>
+              </tr>
+              <tr>
+                <td class="px-3 py-2 align-top"><code class="text-aurora-ink">network.proxy</code></td>
+                <td class="px-3 py-2 align-top"><span class="font-medium text-aurora-ink">Environment</span> &rarr; <code>https://internal.example</code></td>
+                <td class="px-3 py-2 align-top">
+                  <div class="space-y-1">
+                    <div><span class="font-medium text-aurora-ink">Project</span> &rarr; <code>https://public.example</code></div>
+                    <div><span class="font-medium text-aurora-ink">Default</span> &rarr; <code>direct</code></div>
+                  </div>
+                </td>
+                <td class="px-3 py-2 align-top">User, Machine, Project &middot; Machine</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-aurora-edge/60 bg-aurora-card/95 p-6 shadow-lg shadow-black/20">
+        <h2 class="text-xl font-semibold text-aurora-ink">Troubleshooting</h2>
+        <ul class="mt-4 list-disc space-y-2 pl-6 text-aurora-inkMuted">
+          <li>Red text inside the <span class="font-medium text-aurora-ink">Effective value</span> chip indicates validation errors. Open <span class="font-medium text-aurora-ink">Edit…</span> to review details.</li>
+          <li>If the pill you edited stays outlined, another scope still overrides it — compare with the examples above to spot the active layer.</li>
+          <li>A muted pill with a dash is expected when a scope is empty. Fill it only when your workflow needs that override.</li>
+        </ul>
       </section>
 
       <footer class="mb-6 text-center text-sm text-aurora-inkMuted">


### PR DESCRIPTION
## Summary
- retitle the GUI reference and streamline it for the single page layout
- describe the preferred bullet-based scope selectors and tooltip guidance
- add concrete effective/active/missing examples while keeping adapter usage notes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf125e425c83289be3e550fd8d61c8