### PR TITLE
Add accent button style for quick reference

### DIFF
--- a/src/pysigil/ui/theme.py
+++ b/src/pysigil/ui/theme.py
@@ -131,6 +131,25 @@ def apply_theme(
     )
 
     style.configure(
+        "Accent.TButton",
+        background=colors["gold"],
+        foreground=colors["ink"],
+        bordercolor=colors["gold"],
+        borderwidth=1,
+        relief="solid",
+    )
+    style.map(
+        "Accent.TButton",
+        background=[
+            ("disabled", colors["card_edge"]),
+            ("pressed", colors["gold_hi"]),
+            ("active", colors["gold_hi"]),
+        ],
+        foreground=[("disabled", colors["ink_muted"])],
+        bordercolor=[("disabled", colors["card_edge"])],
+    )
+
+    style.configure(
         "TCheckbutton",
         background=colors["bg"],
         foreground=colors["hdr_muted"],

--- a/src/pysigil/ui/tk/__init__.py
+++ b/src/pysigil/ui/tk/__init__.py
@@ -183,6 +183,7 @@ class App:
             header,
             text="Quick Reference",
             command=self._open_quick_reference,
+            style="Accent.TButton",
         ).pack(side="right", padx=(8, 0))
         if self.author_mode:
             ttk.Button(


### PR DESCRIPTION
## Summary
- add an Aurelia accent button style that uses the gold palette color and hover highlight
- apply the accent styling to the Quick Reference button in the main GUI header

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cf1d703b848328a816096d97101664