### PR TITLE
Show field types in edit dialog and scope tooltips

### DIFF
--- a/src/pysigil/ui/tk/dialogs.py
+++ b/src/pysigil/ui/tk/dialogs.py
@@ -61,6 +61,11 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
         ttk.Label(self, text=key, style="Muted.TLabel").pack(
             anchor="w", padx=18, pady=(0, 6)
         )
+        field_type = getattr(info, "type", None)
+        if field_type:
+            ttk.Label(self, text=f"Type: {field_type}", style="Muted.TLabel").pack(
+                anchor="w", padx=18, pady=(0, 12)
+            )
         body = ttk.Frame(self, padding=12, style="Card.TFrame")
         body.pack(fill="both", expand=True, padx=18, pady=(0, 12))
 
@@ -133,6 +138,7 @@ class EditDialog(tk.Toplevel):  # type: ignore[misc]
                 clickable=False,
                 tooltip_title=long_label,
                 tooltip_desc=desc,
+                tooltip_type=field_type,
                 locked=locked,
             )
             pill.grid(row=row, column=0, sticky="w", padx=(0, 8), pady=4)

--- a/src/pysigil/ui/tk/rows.py
+++ b/src/pysigil/ui/tk/rows.py
@@ -78,12 +78,16 @@ class FieldRow(tk.Frame):
 
         self.info_btn: tk.Label | None = None
         self.lbl_desc: ttk.Label | None = None
+        self.field_type: str | None = getattr(info, "type", None) if info else None
         if info:
             desc = info.description or info.description_short
-            tip_lines = [f"Key: {key}"]
+            meta_lines = [f"Key: {key}"]
+            if self.field_type:
+                meta_lines.append(f"Type: {self.field_type}")
+            tip_sections = ["\n".join(meta_lines)]
             if desc:
-                tip_lines.append(desc)
-            tip = "\n\n".join(tip_lines)
+                tip_sections.append(desc)
+            tip = "\n\n".join(tip_sections)
             if desc or key:
                 self.info_btn = tk.Label(
                     self.key_frame,
@@ -233,6 +237,7 @@ class FieldRow(tk.Frame):
                 can_write=can_write,
                 value_provider=value_provider,
                 tooltip_desc=desc,
+                tooltip_type=self.field_type,
             )
 
         # adjust value label height when geometry might change
@@ -286,6 +291,7 @@ class FieldRow(tk.Frame):
         can_write: bool,
         value_provider: Callable[[], Any],
         tooltip_desc: str | None = None,
+        tooltip_type: str | None = None,
     ) -> None:
         """Update or create a single pill widget.
 
@@ -344,6 +350,7 @@ class FieldRow(tk.Frame):
                 on_click=cb,
                 tooltip_title=long_label,
                 tooltip_desc=desc_text,
+                tooltip_type=tooltip_type,
                 locked=locked,
             )
             self._pill_widgets[name] = pill
@@ -356,6 +363,7 @@ class FieldRow(tk.Frame):
             pill.value_provider = value_provider
             pill.tooltip_title = long_label
             pill.tooltip_desc = desc_text
+            pill.tooltip_type = tooltip_type
             pill.on_click = cb
             pill.bind("<Button-1>", lambda e: cb())
             pill.configure(cursor="hand2")
@@ -372,13 +380,18 @@ class FieldRow(tk.Frame):
         label = getattr(info, "label", None) or key
         self.lbl_key.configure(text=label)
         desc = getattr(info, "description", None) or getattr(info, "description_short", None)
-        tip_lines = [f"Key: {key}"]
+        self.field_type = getattr(info, "type", self.field_type)
+        meta_lines = [f"Key: {key}"]
+        if self.field_type:
+            meta_lines.append(f"Type: {self.field_type}")
+        tip_sections = ["\n".join(meta_lines)]
         if desc:
-            tip_lines.append(desc)
-        tip = "\n\n".join(tip_lines)
+            tip_sections.append(desc)
+        tip = "\n\n".join(tip_sections)
         if self.info_btn is not None:
             HoverTip(self.info_btn, lambda: tip)
         HoverTip(self.lbl_key, lambda: tip)
+        self.refresh()
 
 
 __all__ = ["FieldRow"]

--- a/src/pysigil/ui/tk/widgets.py
+++ b/src/pysigil/ui/tk/widgets.py
@@ -105,12 +105,14 @@ class PillButton(tk.Canvas):
         on_click: Callable[[], None] | None = None,
         tooltip_title: str | None = None,
         tooltip_desc: str | None = None,
+        tooltip_type: str | None = None,
         locked: bool = False,
     ) -> None:
         super().__init__(master, height=28, highlightthickness=0, bd=0)
         self.text = text
         self.tooltip_title = tooltip_title or text
         self.tooltip_desc = tooltip_desc
+        self.tooltip_type = tooltip_type
         self.color = color
         self.state = state
         self.locked = locked
@@ -227,6 +229,8 @@ class PillButton(tk.Canvas):
         val = self.value_provider()
         val_txt = str(val) if val is not None else "—"
         parts = [self.tooltip_title]
+        if self.tooltip_type:
+            parts.append(f"Type: {self.tooltip_type}")
         parts.append(f"Value: {val_txt}")
         if self.tooltip_desc:
             parts.append('________________________________')

--- a/tests/ui/test_edit_dialog.py
+++ b/tests/ui/test_edit_dialog.py
@@ -73,6 +73,7 @@ def test_edit_dialog_default_readonly():
     pill = body.grid_slaves(row=row, column=0)[0]
     assert isinstance(pill, PillButton)
     assert adapter.scope_description("default") in pill._tip_text()
+    assert "Type: string" in pill._tip_text()
     dlg.destroy()
     root.destroy()
 
@@ -90,6 +91,7 @@ def test_edit_dialog_shows_metadata():
     texts = [w.cget("text") for w in children if isinstance(w, ttk.Label)]
     assert "Alpha Label" in texts
     assert "alpha" in texts
+    assert "Type: string" in texts
     body = next(w for w in children if isinstance(w, ttk.Frame))
     body_texts = [w.cget("text") for w in body.winfo_children() if isinstance(w, ttk.Label)]
     assert "Short description" in body_texts


### PR DESCRIPTION
## Summary
- show the field type alongside the key title in the edit dialog
- include the field type in scope pill tooltips and info button tooltips
- update tests to cover the new type indicators

## Testing
- pytest tests/ui/test_edit_dialog.py


------
https://chatgpt.com/codex/tasks/task_e_68cf203631288328a0cdef7585fefbc3