### PR TITLE
Honor XDG_CONFIG_HOME for user config directory

### DIFF
--- a/src/pysigil/paths.py
+++ b/src/pysigil/paths.py
@@ -22,6 +22,10 @@ def _app_name(default: str) -> str:
 
 def user_config_dir(app_name: str = "pysigil") -> Path:
     app = _app_name(app_name)
+    override = os.getenv("XDG_CONFIG_HOME")
+    if override:
+        base = Path(override).expanduser()
+        return (base / app).resolve()
     return Path(_uc(appname=app)).resolve()
 
 def user_data_dir(app_name: str = "pysigil") -> Path:


### PR DESCRIPTION
## Summary
- respect the XDG_CONFIG_HOME override when resolving the user config directory
- continue to fall back to platformdirs resolution when the override is absent

## Testing
- pytest tests/test_author_adapter.py tests/test_core_basic.py tests/test_toolkit.py

------
https://chatgpt.com/codex/tasks/task_e_68cf26ad057c8328961595bb80edf69e