### PR TITLE
Handle string values safely in options form formatting

### DIFF
--- a/src/pysigil/ui/options_form.py
+++ b/src/pysigil/ui/options_form.py
@@ -99,8 +99,23 @@ class OptionsForm(ttk.Frame):
         if value is None:
             return None
         ft = TYPE_REGISTRY[key]
-        serialized = ft.adapter.serialize(value)
-        return ft.adapter.parse(serialized) if key == "boolean" else serialized
+        if isinstance(value, str):
+            if key == "boolean":
+                try:
+                    return ft.adapter.parse(value)
+                except Exception:
+                    return value
+            return value
+        try:
+            serialized = ft.adapter.serialize(value)
+        except Exception:
+            return value
+        if key == "boolean":
+            try:
+                return ft.adapter.parse(serialized)
+            except Exception:
+                return serialized
+        return serialized
 
     # ------------------------------------------------------------------
     def get_values(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- leave string values passed to `OptionsForm._format_value` untouched except for boolean parsing
- guard adapter serialization/parsing to fall back to the original value when serialization fails

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf27e4bebc8328832d371d8a2699ff